### PR TITLE
feat: Fix many block sounds

### DIFF
--- a/src/main/java/net/tropicraft/block/BlockBambooChest.java
+++ b/src/main/java/net/tropicraft/block/BlockBambooChest.java
@@ -18,6 +18,7 @@ public class BlockBambooChest extends BlockChest {
 
     public BlockBambooChest() {
         super(0);
+        this.setStepSound(BlockBambooChest.soundTypeWood);
         this.disableStats();
         this.setCreativeTab(TCCreativeTabRegistry.tabBlock);
     }

--- a/src/main/java/net/tropicraft/block/BlockBambooChute.java
+++ b/src/main/java/net/tropicraft/block/BlockBambooChute.java
@@ -38,6 +38,7 @@ public class BlockBambooChute extends BlockTropicraft implements IPlantable {
 
     public BlockBambooChute() {
         super(Material.plants);
+        this.setStepSound(BlockBambooChute.soundTypeGrass);
         final float f = 0.375f;
         this.setBlockBounds(0.5f - f, 0.0f, 0.5f - f, 0.5f + f, 1.0f, 0.5f + f);
         this.setTickRandomly(true);

--- a/src/main/java/net/tropicraft/block/BlockBambooDoor.java
+++ b/src/main/java/net/tropicraft/block/BlockBambooDoor.java
@@ -23,6 +23,7 @@ public class BlockBambooDoor extends BlockDoor {
     public BlockBambooDoor() {
         super(Material.plants);
         this.setBlockTextureName("bambooDoor");
+        this.setStepSound(BlockBambooDoor.soundTypeWood);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/net/tropicraft/block/BlockBambooMug.java
+++ b/src/main/java/net/tropicraft/block/BlockBambooMug.java
@@ -19,6 +19,7 @@ public class BlockBambooMug extends BlockContainer {
 
     public BlockBambooMug() {
         super(Material.plants);
+        this.setStepSound(BlockBambooMug.soundTypeWood);
         this.setBlockBounds(0.3f, 0.0f, 0.3f, 0.7f, 0.45f, 0.7f);
     }
 

--- a/src/main/java/net/tropicraft/block/BlockBongoDrum.java
+++ b/src/main/java/net/tropicraft/block/BlockBongoDrum.java
@@ -32,6 +32,7 @@ public class BlockBongoDrum extends BlockTropicraftMulti {
 
     public BlockBongoDrum(final String[] names) {
         super(names, Material.circuits);
+        this.setStepSound(BlockBongoDrum.soundTypeWood);
         this.setBlockBounds(0.25f, 0.0f, 0.25f, 0.75f, 1.0f, 0.75f);
         this.setLightOpacity(255);
         this.setCreativeTab(TCCreativeTabRegistry.tabMisc);

--- a/src/main/java/net/tropicraft/block/BlockChunkOHead.java
+++ b/src/main/java/net/tropicraft/block/BlockChunkOHead.java
@@ -6,6 +6,7 @@ public class BlockChunkOHead extends BlockTropicraft {
 
     public BlockChunkOHead() {
         super(Material.rock);
+        this.setStepSound(BlockChunkOHead.soundTypeStone);
         this.setBlockName("chunk");
         this.setHardness(2.0f);
         this.setResistance(30.0f);

--- a/src/main/java/net/tropicraft/block/BlockCoconut.java
+++ b/src/main/java/net/tropicraft/block/BlockCoconut.java
@@ -10,6 +10,7 @@ public class BlockCoconut extends BlockTropicraft {
 
     public BlockCoconut() {
         super(Material.gourd);
+        this.setStepSound(BlockCoconut.soundTypeWood);
         final float f = 0.225f;
         this.setBlockBounds(0.5f - f, f, 0.5f - f, 0.5f + f, 1.0f - f, 0.5f + f);
         this.setCreativeTab(TCCreativeTabRegistry.tabFood);

--- a/src/main/java/net/tropicraft/block/BlockCoffeePlant.java
+++ b/src/main/java/net/tropicraft/block/BlockCoffeePlant.java
@@ -36,6 +36,7 @@ public class BlockCoffeePlant extends BlockTropicraft {
 
     public BlockCoffeePlant() {
         super(Material.plants);
+        this.setStepSound(BlockCoffeePlant.soundTypeGrass);
         this.setTickRandomly(true);
         this.disableStats();
         this.setCreativeTab((CreativeTabs) null);

--- a/src/main/java/net/tropicraft/block/BlockFirePit.java
+++ b/src/main/java/net/tropicraft/block/BlockFirePit.java
@@ -10,6 +10,7 @@ public class BlockFirePit extends BlockTropicraft implements ITileEntityProvider
 
     public BlockFirePit() {
         super(Material.circuits);
+        this.setStepSound(BlockFirePit.soundTypeWood);
         this.setBlockTextureName("firePit");
         this.setBlockBoundsForItemRender();
         this.lightValue = 15;

--- a/src/main/java/net/tropicraft/block/BlockKoaChest.java
+++ b/src/main/java/net/tropicraft/block/BlockKoaChest.java
@@ -16,6 +16,7 @@ public class BlockKoaChest extends BlockChest {
 
     public BlockKoaChest() {
         super(0);
+        this.setStepSound(BlockKoaChest.soundTypeWood);
         this.disableStats();
         this.setCreativeTab(TCCreativeTabRegistry.tabBlock);
     }

--- a/src/main/java/net/tropicraft/block/BlockMineralSands.java
+++ b/src/main/java/net/tropicraft/block/BlockMineralSands.java
@@ -28,6 +28,7 @@ public class BlockMineralSands extends BlockFalling {
 
     public BlockMineralSands() {
         super(Material.sand);
+        this.setStepSound(BlockMineralSands.soundTypeSand);
         this.setCreativeTab(TCCreativeTabRegistry.tabBlock);
         this.setHardness(0.5f);
     }

--- a/src/main/java/net/tropicraft/block/BlockPurifiedSand.java
+++ b/src/main/java/net/tropicraft/block/BlockPurifiedSand.java
@@ -12,6 +12,7 @@ public class BlockPurifiedSand extends BlockFalling {
 
     public BlockPurifiedSand() {
         super(Material.sand);
+        this.setStepSound(BlockPurifiedSand.soundTypeSand);
         this.setHardness(0.5f);
         this.setCreativeTab(TCCreativeTabRegistry.tabBlock);
     }

--- a/src/main/java/net/tropicraft/block/BlockSifter.java
+++ b/src/main/java/net/tropicraft/block/BlockSifter.java
@@ -21,6 +21,7 @@ public class BlockSifter extends BlockTropicraft implements ITileEntityProvider 
 
     public BlockSifter() {
         super(Material.wood);
+        this.setStepSound(BlockSifter.soundTypeWood);
     }
 
     public TileEntity createNewTileEntity(final World var1, final int var2) {

--- a/src/main/java/net/tropicraft/block/BlockTikiTorch.java
+++ b/src/main/java/net/tropicraft/block/BlockTikiTorch.java
@@ -29,6 +29,7 @@ public class BlockTikiTorch extends BlockTropicraft {
 
     public BlockTikiTorch() {
         super(Material.circuits);
+        this.setStepSound(BlockTikiTorch.soundTypeWood);
         this.setTickRandomly(true);
         this.setCreativeTab((CreativeTabs) null);
         this.lightValue = 15;

--- a/src/main/java/net/tropicraft/block/BlockTropicraftFence.java
+++ b/src/main/java/net/tropicraft/block/BlockTropicraftFence.java
@@ -19,6 +19,7 @@ public class BlockTropicraftFence extends BlockFence {
     public BlockTropicraftFence(final String name, final String textureName, final BlockTropicraftFenceGate fenceGate,
         final Material material) {
         super(name, material);
+        this.setStepSound(BlockTropicraftFence.soundTypeWood);
         this.setCreativeTab(TCCreativeTabRegistry.tabDecorations);
         this.setBlockName(name);
         this.setBlockTextureName(textureName);

--- a/src/main/java/net/tropicraft/block/BlockTropicraftFenceGate.java
+++ b/src/main/java/net/tropicraft/block/BlockTropicraftFenceGate.java
@@ -18,6 +18,7 @@ public class BlockTropicraftFenceGate extends BlockFenceGate {
     public BlockTropicraftFenceGate(final Block block, final int meta, final String name, final Material material) {
         this.blockForTexture = block;
         this.textureMeta = meta;
+        this.setStepSound(BlockTropicraftFenceGate.soundTypeWood);
         this.setCreativeTab(TCCreativeTabRegistry.tabDecorations);
     }
 

--- a/src/main/java/net/tropicraft/block/BlockTropicraftSapling.java
+++ b/src/main/java/net/tropicraft/block/BlockTropicraftSapling.java
@@ -37,6 +37,7 @@ public class BlockTropicraftSapling extends BlockSapling implements IGrowable {
 
     public BlockTropicraftSapling(final String[] names) {
         this.names = names;
+        this.setStepSound(BlockTropicraftSapling.soundTypeGrass);
         this.setTickRandomly(true);
         this.disableStats();
         this.setCreativeTab(TCCreativeTabRegistry.tabBlock);

--- a/src/main/java/net/tropicraft/registry/TCBlockRegistry.java
+++ b/src/main/java/net/tropicraft/registry/TCBlockRegistry.java
@@ -222,7 +222,8 @@ public class TCBlockRegistry {
         thatchBundle = (BlockTropicraft) new BlockBundle("thatch");
         coral = (BlockTropicraft) new BlockCoral(TCNames.coralNames);
         bambooBundle = (BlockTropicraft) new BlockBundle("bambooBundle").setHardness(1.0f)
-            .setResistance(0.1f);
+            .setResistance(0.1f)
+            .setStepSound(Block.soundTypeWood);
         logs = (BlockTropicraft) new BlockTropicraftLog(TCNames.logNames);
         planks = (BlockTropicraft) new BlockTropicraftPlank(TCNames.plankNames);
         bambooStairs = new BlockTropicraftStairs("bambooStairs", (Block) TCBlockRegistry.bambooBundle, 0);

--- a/src/main/java/net/tropicraft/registry/TCBlockRegistry.java
+++ b/src/main/java/net/tropicraft/registry/TCBlockRegistry.java
@@ -219,7 +219,7 @@ public class TCBlockRegistry {
         azuriteOre = new BlockTropicraftOre().setHardness(3.0f)
             .setResistance(5.0f);
         oreBlocks = (BlockTropicraft) new BlockTropicraftMulti(TCNames.oreBlockNames);
-        thatchBundle = (BlockTropicraft) new BlockBundle("thatch");
+        thatchBundle = (BlockTropicraft) new BlockBundle("thatch").setStepSound(Block.soundTypeGrass);
         coral = (BlockTropicraft) new BlockCoral(TCNames.coralNames);
         bambooBundle = (BlockTropicraft) new BlockBundle("bambooBundle").setHardness(1.0f)
             .setResistance(0.1f)


### PR DESCRIPTION
## Problem

   Players reported that bamboo blocks play the wrong sounds (stone clunks on break and footstep).

   The cause is general, not bamboo-specific: `Block`'s constructor defaults `stepSound` to
   `soundTypeStone`, and vanilla assigns each block's real material sound **per instance** during
   `Block` registration rather than in the `BlockX` constructors. As a result every Tropicraft block
   subclass — including subclasses of `BlockChest`, `BlockDoor`, `BlockFence`, `BlockSapling` and
   `BlockFalling` — silently inherited the stone default.

   ## Changes

   Every block below was playing `dig.stone` / `step.stone` unless noted.

   ### Bamboo

   | Block | Sound | Vanilla reference |
   | --- | --- | --- |
   | Bamboo Bundle | `soundTypeWood` | — |
   | Bamboo Stairs | `soundTypeWood` (inherited from bundle) | `oak_stairs` |
   | Bamboo Fence | `soundTypeWood` | `fence` |
   | Bamboo Fence Gate | `soundTypeWood` | `fence_gate` |
   | Bamboo Door | `soundTypeWood` | `wooden_door` |
   | Bamboo Chest | `soundTypeWood` | `chest` |
   | Bamboo Mug | `soundTypeWood` | — |
   | Bamboo Chute | `soundTypeGrass` | `reeds` |

   ### Everything else hit by the same bug

   | Block | Sound | Vanilla reference |
   | --- | --- | --- |
   | Palm Plank Fence / Fence Gate | `soundTypeWood` | `fence`, `fence_gate` |
   | Thatch Bundle (+ Thatch Stairs) | `soundTypeGrass` | `hay_block` |
   | Chunk O' Head (+ Stairs) | `soundTypeStone` (now explicit) | — |
   | Koa Chest | `soundTypeWood` | `chest` |
   | Purified Sand | `soundTypeSand` | `sand` |
   | Mineral Sands (all 4 variants) | `soundTypeSand` | `sand` |
   | Saplings (all 6 variants) | `soundTypeGrass` | `sapling` |
   | Coffee Plant | `soundTypeGrass` | `reeds` |
   | Sifter | `soundTypeWood` | `crafting_table` |
   | Tiki Torch | `soundTypeWood` | `torch` |
   | Coconut | `soundTypeWood` | `pumpkin`, `melon_block` |
   | Fire Pit | `soundTypeWood` | `fire` |
   | Bongo Drum (all 3 sizes) | `soundTypeWood` | judgement call, see below |

   Sounds are set in each block's own constructor; the two `BlockBundle` instances (bamboo/thatch)
   differ, so those are set where they are constructed in `TCBlockRegistry`. Stairs needed no change —
   `BlockStairs` already copies the base block's sound.

   ## Verified already correct (no change)

   Logs, planks and flowers (already set); leaves and tall flowers/pineapple plants (get grass from
   `BlockLeaves` / `BlockDoublePlant` constructors); ores and the compressed ore blocks, portal wall
   and the fluids (`soundTypePiston` is byte-identical to the stone default); rain stopper, flower pot,
   curare bowl, purchase plate and the drink mixer.

   ## Known limitations & open questions

   - **Slabs are unchanged.** `singleSlabs`/`doubleSlabs` carry Bamboo/Thatch/Chunk/Palm in one Block
     class, and `stepSound` is a plain public field read directly by `Entity`, `RenderGlobal`,
     `PlayerControllerMP` and `ItemSlab` — per-metadata sounds are not possible in 1.7.10 without a
     coremod/`ITransformer`.
   - `BlockTropicraftFence` now hardcodes wood for all instances. `en_US.lang` still contains unused
     entries for chunk/thatch/mahogany fences; if those are ever registered they will need the sound
     moved to a constructor parameter.
   - Left on stone pending a decision: curare bowl, Koa Trader purchase plate, the compressed
     eudialyte/zircon/azurite blocks and Block of Cubic Zirconium (vanilla splits `lapis_block` stone vs
     metal blocks), the coral reef block, and the bamboo flower pot (currently vanilla-accurate).
   - The bongo drum is intentionally *not* vanilla-matched — the closest vanilla object, `noteblock`,
     is left on the stone default, which reads wrong for a drum.

   ## Testing

   `./gradlew compileJava spotlessCheck` pass. `checkstyleMain` cannot run offline (checkstyle 10.24.0
   is not in the local cache). Behaviour is unchanged apart from block break/step/placement sounds.

   Closes #2 