### PR TITLE
Fix Tropicraft blocks not being flammable (Fixes #12)

### DIFF
--- a/src/main/java/net/tropicraft/block/BlockTropicraftLog.java
+++ b/src/main/java/net/tropicraft/block/BlockTropicraftLog.java
@@ -8,7 +8,6 @@ import net.minecraft.item.Item;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
-import net.minecraftforge.common.util.ForgeDirection;
 import net.tropicraft.registry.TCBlockRegistry;
 import net.tropicraft.registry.TCCreativeTabRegistry;
 
@@ -56,10 +55,6 @@ public class BlockTropicraftLog extends BlockTropicraftMulti {
                 world.setBlockMetadataWithNotify(i, j, k, 0, 3);
             }
         }
-    }
-
-    public boolean isFireSource(final World world, final int x, final int y, final int z, final ForgeDirection side) {
-        return true;
     }
 
     public int getRenderType() {

--- a/src/main/java/net/tropicraft/registry/TCBlockRegistry.java
+++ b/src/main/java/net/tropicraft/registry/TCBlockRegistry.java
@@ -123,27 +123,41 @@ public class TCBlockRegistry {
         registerBlock(TCBlockRegistry.azuriteOre, "oreAzurite");
         registerMultiBlock((Block) TCBlockRegistry.oreBlocks, "blockOre", TCNames.oreBlockNames);
         registerBlock((Block) TCBlockRegistry.thatchBundle, "thatch");
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.thatchBundle, 60, 20);
         registerMultiBlock((Block) TCBlockRegistry.coral, "coral", TCNames.coralNames);
         registerBlock((Block) TCBlockRegistry.bambooBundle, "bambooBundle");
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.bambooBundle, 5, 20);
         registerMultiBlock((Block) TCBlockRegistry.logs, "log", TCNames.logNames);
         Blocks.fire.setFireInfo((Block) TCBlockRegistry.logs, 5, 5);
         registerMultiBlock((Block) TCBlockRegistry.planks, "plank", TCNames.plankNames);
         Blocks.fire.setFireInfo((Block) TCBlockRegistry.planks, 5, 5);
         registerBlock((Block) TCBlockRegistry.bambooStairs, "bambooStairs");
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.bambooStairs, 5, 20);
         registerBlock((Block) TCBlockRegistry.thatchStairs, "thatchStairs");
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.thatchStairs, 60, 20);
         registerBlock((Block) TCBlockRegistry.palmStairs, "palmStairs");
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.palmStairs, 5, 20);
         registerBlock((Block) TCBlockRegistry.mahoganyStairs, "mahoganyStairs");
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.mahoganyStairs, 5, 20);
         registerMultiBlock((Block) TCBlockRegistry.tallFlowers, "tallFlower", TCNames.tallFlowerNames);
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.tallFlowers, 60, 100);
         registerMultiBlock((Block) TCBlockRegistry.pineapple, "pineapple", TCNames.pineappleNames);
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.pineapple, 60, 100);
         registerBlockNoName((Block) TCBlockRegistry.bambooFence, "bambooFence");
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.bambooFence, 5, 20);
         registerBlockNoName((Block) TCBlockRegistry.palmFence, "palmFence");
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.palmFence, 5, 20);
         registerMultiBlock((Block) TCBlockRegistry.saplings, "sapling", TCNames.saplingNames);
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.saplings, 30, 60);
         registerBlock((Block) TCBlockRegistry.coffeePlant, "coffeePlant");
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.coffeePlant, 60, 100);
         registerBlock((Block) TCBlockRegistry.bambooFenceGate, "bambooFenceGate");
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.bambooFenceGate, 5, 20);
         registerBlock((Block) TCBlockRegistry.palmFenceGate, "palmFenceGate");
-        Blocks.fire.setFireInfo((Block) TCBlockRegistry.palmFenceGate, 5, 5);
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.palmFenceGate, 5, 20);
         registerBlock((Block) TCBlockRegistry.tikiTorch, "tikiTorch");
         registerBlock((Block) TCBlockRegistry.bambooDoor, "bambooDoor");
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.bambooDoor, 5, 20);
         registerMultiBlock(
             (Block) TCBlockRegistry.singleSlabs,
             "singleSlabs",
@@ -157,6 +171,7 @@ public class TCBlockRegistry {
         registerBlock((Block) TCBlockRegistry.tropicsWater, "tropicsWater");
         registerBlock((Block) TCBlockRegistry.rainStopper, "rainStopper");
         registerMultiBlock((Block) TCBlockRegistry.flowers, "flower", TCNames.flowerIndices);
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.flowers, 60, 100);
         registerBlock((Block) TCBlockRegistry.flowerPot, "flowerPot");
         registerBlock((Block) TCBlockRegistry.coconut, "coconut");
         registerBlock(TCBlockRegistry.firePit, "firePit");
@@ -168,12 +183,15 @@ public class TCBlockRegistry {
         registerBlock((Block) TCBlockRegistry.palmLeaves, "leafPalm");
         Blocks.fire.setFireInfo((Block) TCBlockRegistry.palmLeaves, 30, 60);
         registerMultiBlock((Block) TCBlockRegistry.rainforestLeaves, "leafRainforest", TCNames.rainforestLeafNames);
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.rainforestLeaves, 30, 60);
         registerBlock((Block) TCBlockRegistry.bambooChute, "bambooChute");
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.bambooChute, 60, 100);
         registerBlock((Block) TCBlockRegistry.purifiedSand, "purifiedSand");
         registerMultiBlock((Block) TCBlockRegistry.mineralSands, "mineralSand", TCNames.mineralSandNames);
         registerBlock((Block) TCBlockRegistry.sifter, "sifter");
         registerBlock((Block) TCBlockRegistry.curareBowl, "curareBowl");
         registerMultiBlock((Block) TCBlockRegistry.bongoDrum, "bongoDrum", TCNames.bongoDrumNames);
+        Blocks.fire.setFireInfo((Block) TCBlockRegistry.bongoDrum, 5, 20);
         registerBlock((Block) TCBlockRegistry.koaChest, "koaChest");
         registerBlock((Block) TCBlockRegistry.purchasePlate, "purchasePlate");
         registerBlock((Block) TCBlockRegistry.bambooMug, "bambooMug");


### PR DESCRIPTION
## Description

   In 1.7.10 Forge, a block can only burn if it is registered on the vanilla fire
   block via `Blocks.fire.setFireInfo(block, encouragement, flammability)`. Almost
   no Tropicraft blocks had this registration, so the vast majority of modded
   blocks could not catch fire or burn (issue #12). Only the palm/mahogany logs,
   planks, palm fence gate, and fruit/palm leaves were registered.

   This PR also fixes a related latent bug: `BlockTropicraftLog` overrode
   `isFireSource()` to unconditionally return `true` (netherrack-style behavior),
   which made any fire touching a Tropicraft log permanent, rain-proof, and
   infinite — including the log foundations of the Forest Altar Ruin.

   ## Changes

   ### `BlockTropicraftLog.java`
   - Removed the erroneous `isFireSource()` override and its now-unused
     `ForgeDirection` import. Tropicraft logs now burn like vanilla logs
     (encouragement 5 / flammability 5, as already registered).

   ### `TCBlockRegistry.java`
   - Added `setFireInfo` registrations for all previously non-burning blocks,
     using vanilla-analog values:

   | Blocks | Encouragement / Flammability | Vanilla analog |
   |---|---|---|
   | Bamboo bundle, bamboo fence/fence gate/door/stairs, palm fence/fence gate/stairs, mahogany stairs, bongo drum | 5
 / 20 | planks, fences, wood stairs |
   | Thatch bundle & thatch stairs | 60 / 20 | hay block |
   | Rainforest leaves, saplings | 30 / 60 | leaves |
   | Flowers, tall flowers, coffee plant, pineapple, bamboo chute | 60 / 100 | tall grass / flowers |
   | Palm fence gate | 5 / 20 (normalized) | fence gate (was an inconsistent 5 / 5) |

   ## Deliberately excluded
   - **Slabs** — the slab block mixes flammable (bamboo/thatch/palm) and
     non-flammable (chunk) variants under one block ID with metadata; a correct
     fix requires metadata-sensitive `isFlammable`/`getFireSpreadSpeed` overrides
     and is deferred until the slab implementation is reworked.
   - **Stone/utility blocks** (ores, coral, chests, tiki torch, portal, etc.) —
     match their vanilla analogs (chests and torches do not burn).

   ## Testing
   - `compileJava`, `checkstyleMain`, and `spotlessCheck` all pass.

   ## Follow-up
   - The Forest Altar Ruin's eternal netherrack fire now sits adjacent to
     newly-flammable structure blocks (palm fences/stairs, log foundation) and
     will slowly burn the ruin down — vanilla-consistent, but we may want to
     isolate the fire in `WorldGenForestAltarRuin` in a follow-up.

   Closes #12