### PR TITLE
Fix broken unicode characters corrupting item names and GUI text (Fixes #5)

### DIFF
--- a/src/main/java/net/tropicraft/client/gui/GuiTropicalBook.java
+++ b/src/main/java/net/tropicraft/client/gui/GuiTropicalBook.java
@@ -332,7 +332,7 @@ public class GuiTropicalBook extends GuiScreen {
                 case INFO: {
                     final String pageTitle = this.book.isPageVisible(this.selectedIndex)
                         ? this.book.getPageTitleByIndex(this.selectedIndex)
-                        : "�nPage not found";
+                        : "§nPage not found";
                     this.fontRendererObj.drawString(
                         pageTitle,
                         this.width / 2 + 150 - this.fontRendererObj.getStringWidth(pageTitle),

--- a/src/main/java/net/tropicraft/item/ItemCocktail.java
+++ b/src/main/java/net/tropicraft/item/ItemCocktail.java
@@ -62,7 +62,7 @@ public class ItemCocktail extends ItemTropicraft {
         }
         final Drink drink = Drink.drinkList[par1ItemStack.stackTagCompound.getByte("DrinkID")];
         if (drink != null) {
-            par3List.add("�o" + drink.displayName);
+            par3List.add("§o" + drink.displayName);
         }
     }
 

--- a/src/main/java/net/tropicraft/item/ItemCurare.java
+++ b/src/main/java/net/tropicraft/item/ItemCurare.java
@@ -142,6 +142,6 @@ public class ItemCurare extends ItemTropicraft {
     static {
         effectNames = new String[] { "paralyze", "poison", "moveSlowdown", "harm", "confusion", "hunger", "weakness" };
         colors = new int[] { 16758271, 2461347, 13621209, 14672442, 5322747, 14754852, 7129087 };
-        tooltipText = new String[] { "�d", "�3", "�7", "�6", "�1", "�4", "�9" };
+        tooltipText = new String[] { "§d", "§3", "§7", "§6", "§1", "§4", "§9" };
     }
 }

--- a/src/main/java/net/tropicraft/item/ItemDart.java
+++ b/src/main/java/net/tropicraft/item/ItemDart.java
@@ -74,6 +74,6 @@ public class ItemDart extends ItemTropicraft {
     static {
         dartNames = new String[] { "paralyze", "poison", "moveSlowdown", "harm", "confusion", "hunger", "weakness" };
         colors = new int[] { 16758271, 2461347, 13621209, 14672442, 5322747, 14754852, 7129087 };
-        tooltipText = new String[] { "�d", "�3", "�7", "�6", "�1", "�4", "�9" };
+        tooltipText = new String[] { "§d", "§3", "§7", "§6", "§1", "§4", "§9" };
     }
 }

--- a/src/main/java/net/tropicraft/util/ColorHelper.java
+++ b/src/main/java/net/tropicraft/util/ColorHelper.java
@@ -13,7 +13,7 @@ public class ColorHelper {
     private static BiMap<Integer, Integer> woolValues;
     private static ArrayList<Integer> colorValues;
     public static int DEFAULT_VALUE;
-    public static final char COLOR_CHARACTER = '�';
+    public static final char COLOR_CHARACTER = '§';
 
     public static void init() {
         for (final int color : ItemDye.field_150922_c) {
@@ -26,7 +26,7 @@ public class ColorHelper {
     }
 
     public static String color(final int val) {
-        return '�' + Integer.toHexString(val);
+        return '§' + Integer.toHexString(val);
     }
 
     public static int getNumColors() {


### PR DESCRIPTION
> **Fix broken unicode characters corrupting item names and GUI text**

   This PR fixes a bug where the Minecraft formatting code character `§` (U+00A7) was mangled into the Unicode
 Replacement Character `` (U+FFFD) across multiple source files. This corruption caused item tooltip colors, cocktail
 drink names, tropical book "Page not found" text, and any other formatted strings to display as garbled text in-game.

   **Root cause:** When source files containing `§` were decompiled or re-encoded, the encoding was lost and every `§`
 was silently replaced with `` (U+FFFD). Minecraft's text renderer interprets `§` followed by a letter or digit as a
 formatting or color code — with the broken `` character in its place, none of these codes were recognized, resulting
 in corrupt item names and GUI text.

   **Files changed:**

   | File | What was fixed |
   |------|----------------|
   | `ColorHelper.java` | `COLOR_CHARACTER` constant and `color()` helper method — affects colorized text across the
 mod |
   | `ItemDart.java` | 7 color codes (`§d`, `§3`, `§7`, `§6`, `§1`, `§4`, `§9`) in dart item tooltips |
   | `ItemCurare.java` | Same 7 color codes in curare item tooltips |
   | `ItemCocktail.java` | Italic formatting (`§o`) on cocktail drink names |
   | `GuiTropicalBook.java` | Underline formatting (`§n`) on the "Page not found" fallback text |

   All occurrences of `` have been replaced with the correct `§` character, restoring proper text formatting throughout
 the mod.

   Closes #5