### PR TITLE
Fix invisible home tree blocks (Fixes #13)

### DIFF
--- a/src/main/java/net/tropicraft/world/worldgen/TCGenBase.java
+++ b/src/main/java/net/tropicraft/world/worldgen/TCGenBase.java
@@ -75,7 +75,6 @@ public abstract class TCGenBase extends WorldGenerator {
                 final double d = (i - x) * (i - x) + (k - z) * (k - z);
                 if (d <= outerRadius * outerRadius && d >= innerRadius * innerRadius
                     && !allowedBlockList.contains(this.worldObj.getBlock(x, j, z))) {
-                    System.out.println("t2");
                     return false;
                 }
             }
@@ -119,7 +118,7 @@ public abstract class TCGenBase extends WorldGenerator {
             int chunkX = ai3[0] >> 4;
             int chunkZ = ai3[2] >> 4;
 
-            Chunk chunk = world.getChunkFromChunkCoords(chunkX >> 4, chunkZ >> 4);
+            Chunk chunk = world.getChunkFromChunkCoords(chunkX, chunkZ);
             if (!chunk.isChunkLoaded) {
                 return false;
             }
@@ -166,7 +165,7 @@ public abstract class TCGenBase extends WorldGenerator {
                 chunkX = blockChunkX;
                 chunkZ = blockChunkZ;
 
-                Chunk chunk = worldObj.getChunkFromChunkCoords(chunkX >> 4, chunkZ >> 4);
+                Chunk chunk = worldObj.getChunkFromChunkCoords(chunkX, chunkZ);
                 if (!chunk.isChunkLoaded) {
                     return;
                 }
@@ -266,7 +265,6 @@ public abstract class TCGenBase extends WorldGenerator {
             }
         }
         for (int k = 0, l = ai2[j] + byte4; k != l; k += byte4) {
-            System.out.println("watwat");
             ai3[j] = MathHelper.floor_double(ai[j] + k + 0.5);
             ai3[byte2] = MathHelper.floor_double(ai[byte2] + k * d + 0.5);
             ai3[byte3] = MathHelper.floor_double(ai[byte3] + k * d2 + 0.5);

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenHomeTree.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenHomeTree.java
@@ -242,7 +242,7 @@ public class WorldGenHomeTree extends TCGenBase {
             return false;
         }
 
-        return this.worldObj.setBlock(i, j, k, woodID2, meta, 0);
+        return this.worldObj.setBlock(i, j, k, woodID2, meta, TCGenBase.blockGenNotifyFlag);
     }
 
     private boolean canReplaceBlock(Block block) {


### PR DESCRIPTION
# Fix invisible home tree blocks

   Fixes #13

   ## Problem

   Home tree branches and canopy blocks could generate as **invisible blocks** on the client — present server-side
 (solid, collidable) but never rendered. This occurred when generation wrote into neighbor chunks that had already been
 sent to the client.

   ## Root causes

   1. **Suppressed client updates in `WorldGenHomeTree.placeBlock`**
      `setBlock(..., flag 0)` suppresses the block-update notification (flag `2`), so any home tree block written into
 an already-loaded, already-sent chunk never triggered a re-render on the client.

   2. **Double bit-shift bug in `TCGenBase`**
      In `checkBlockLine` and `placeBlockLine`, `chunkX`/`chunkZ` were already chunk coordinates (`coord >> 4`) but
 were shifted **again** before being passed to `getChunkFromChunkCoords`, fetching a chunk 16 chunks (256 blocks) away.
 As a result:
      - the `isChunkLoaded` guards checked the wrong chunk,
      - `checkBlockLine` could pass/fail based on blocks read from the wrong chunk,
      - `placeBlockLine` could pass the guard while the *actual* target chunk was unloaded, forcing a synchronous chunk
 load during decoration (cascading worldgen) — or silently truncating branches.

   ## Changes

   - `WorldGenHomeTree.placeBlock`: use `TCGenBase.blockGenNotifyFlag` instead of flag `0`, so all placed blocks
 trigger client updates (honors the flag-3 override used by sapling growth).
   - `TCGenBase.checkBlockLine` / `placeBlockLine`: remove the erroneous second `>> 4` so the guards inspect the
 correct chunk.
   - Remove leftover debug `System.out.println` calls (`"t2"`, `"watwat"`).

   ## Testing

   - `./gradlew compileJava` — ✅
   - `./gradlew checkstyleMain` — ✅
   - In-game: generate a fresh rainforest world and inspect home trees near chunk borders (F3+G). Branches and leaf
 canopies should render fully on both sides of chunk boundaries with no invisible/collidable-only blocks, and no
 cascading worldgen warnings in the log.

   ## Note

   Issue #14 (mahogany tree shape regression) is a separate bug originating from a different cause (the `6ccba16`
 generator rewrite changing tree logic) and is intentionally not addressed here.

Closes #13 