### PR TITLE
Fix mahogany tree shape regression (Fixes #14)

### DIFF
--- a/src/main/java/net/tropicraft/world/worldgen/TCGenBase.java
+++ b/src/main/java/net/tropicraft/world/worldgen/TCGenBase.java
@@ -2,10 +2,8 @@ package net.tropicraft.world.worldgen;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
-import java.util.Set;
 
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
@@ -75,7 +73,6 @@ public abstract class TCGenBase extends WorldGenerator {
                 final double d = (i - x) * (i - x) + (k - z) * (k - z);
                 if (d <= outerRadius * outerRadius && d >= innerRadius * innerRadius
                     && !allowedBlockList.contains(this.worldObj.getBlock(x, j, z))) {
-                    System.out.println("t2");
                     return false;
                 }
             }
@@ -119,7 +116,7 @@ public abstract class TCGenBase extends WorldGenerator {
             int chunkX = ai3[0] >> 4;
             int chunkZ = ai3[2] >> 4;
 
-            Chunk chunk = world.getChunkFromChunkCoords(chunkX >> 4, chunkZ >> 4);
+            Chunk chunk = world.getChunkFromChunkCoords(chunkX, chunkZ);
             if (!chunk.isChunkLoaded) {
                 return false;
             }
@@ -151,8 +148,6 @@ public abstract class TCGenBase extends WorldGenerator {
         int chunkX = start[0] >> 4;
         int chunkZ = start[2] >> 4;
 
-        Set<String> placedBlocks = new HashSet<>();
-
         int[] currentPos = new int[3];
         for (int k = 0, l = difference[largestDifferenceIndex] + sign; k != l; k += sign) {
             currentPos[largestDifferenceIndex] = MathHelper.floor_double(start[largestDifferenceIndex] + k + 0.5);
@@ -166,18 +161,15 @@ public abstract class TCGenBase extends WorldGenerator {
                 chunkX = blockChunkX;
                 chunkZ = blockChunkZ;
 
-                Chunk chunk = worldObj.getChunkFromChunkCoords(chunkX >> 4, chunkZ >> 4);
+                Chunk chunk = worldObj.getChunkFromChunkCoords(chunkX, chunkZ);
                 if (!chunk.isChunkLoaded) {
-                    return;
+                    continue;
                 }
             }
-
-            String blockKey = currentPos[0] + "_" + currentPos[1] + "_" + currentPos[2];
 
             if (worldObj.getBlock(currentPos[0], currentPos[1], currentPos[2]) != block) {
                 worldObj
                     .setBlock(currentPos[0], currentPos[1], currentPos[2], block, meta, TCGenBase.blockGenNotifyFlag);
-                placedBlocks.add(blockKey);
             }
         }
     }
@@ -266,7 +258,6 @@ public abstract class TCGenBase extends WorldGenerator {
             }
         }
         for (int k = 0, l = ai2[j] + byte4; k != l; k += byte4) {
-            System.out.println("watwat");
             ai3[j] = MathHelper.floor_double(ai[j] + k + 0.5);
             ai3[byte2] = MathHelper.floor_double(ai[byte2] + k * d + 0.5);
             ai3[byte3] = MathHelper.floor_double(ai[byte3] + k * d2 + 0.5);

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenTallTree.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenTallTree.java
@@ -131,7 +131,7 @@ public class WorldGenTallTree extends TCGenBase {
         for (int x = i - leafSize2; x <= i + leafSize2; ++x) {
             for (int z = k - leafSize2; z <= k + leafSize2; ++z) {
                 for (int y4 = j + height + 3; y4 <= j + height + 6; ++y4) {
-                    if (this.rand.nextInt(5) == 0) {
+                    if (this.rand.nextInt(VINE_CHANCE) == 0) {
                         vineCoordinates.add(new ChunkCoordinates(x, y4, z));
                     }
                 }
@@ -142,26 +142,15 @@ public class WorldGenTallTree extends TCGenBase {
     }
 
     private void placeVines(List<ChunkCoordinates> vineCoordinates) {
-        int vineChance = 5;
-
         for (ChunkCoordinates pos : vineCoordinates) {
-            int posX = pos.posX;
-            int posY = pos.posY;
-            int posZ = pos.posZ;
-
-            if (this.rand.nextInt(vineChance) == 0 && canPlaceVines(posX, posY, posZ)) {
-                generateVinesAt(posX, posY, posZ);
+            if (canPlaceVines(pos.posX, pos.posY, pos.posZ)) {
+                generateVinesAt(pos.posX, pos.posY, pos.posZ);
             }
         }
     }
 
     private boolean canPlaceVines(int x, int y, int z) {
-        Block vineBlock = Blocks.vine;
-
         World world = this.worldObj;
-
-        int chunkX = x >> 4;
-        int chunkZ = z >> 4;
 
         Chunk chunk = world.getChunkFromChunkCoords(x >> 4, z >> 4);
         if (!chunk.isChunkLoaded) {
@@ -176,7 +165,7 @@ public class WorldGenTallTree extends TCGenBase {
         boolean isAirAbove = blockAbove.isAir(world, x, y + 1, z);
         boolean isAirBelow = blockBelow.isAir(world, x, y - 1, z);
 
-        return isAir && isAirAbove && isAirBelow && blockAtPos == vineBlock && !vineExistsNearby(x, y, z);
+        return isAir && isAirAbove && isAirBelow && !vineExistsNearby(x, y, z);
     }
 
     private boolean vineExistsNearby(int x, int y, int z) {
@@ -200,13 +189,9 @@ public class WorldGenTallTree extends TCGenBase {
         List<Integer> validSides = new ArrayList<>();
 
         for (int m = 2; m <= 5; ++m) {
-            int blockX = x + Facing.offsetsXForSide[m];
-            int blockY = y + Facing.offsetsYForSide[m];
-            int blockZ = z + Facing.offsetsZForSide[m];
-
-            if (this.worldObj.isAirBlock(blockX, blockY, blockZ)) {
+            if (vineBlock.canPlaceBlockOnSide(this.worldObj, x, y, z, m)) {
                 validSides.add(1 << Direction.facingToDirection[Facing.oppositeSide[m]]);
-            } else {}
+            }
         }
 
         if (!validSides.isEmpty()) {


### PR DESCRIPTION
## Problem

   Mahogany (tall) trees generated with truncated, lopsided canopies and branches
   that abruptly stopped mid-way, no longer matching the shape produced by the
   last official TC 1.7 release. Trees crossing chunk boundaries were affected
   worst, appearing clipped in rectangular wedges.

   ## Root causes

   Regression introduced by `6ccba16` ("Greatly reduce cascading worldgens") — the
   same commit that caused #13 (fixed separately in #19):

   1. **Double bit-shift bug in `TCGenBase`**
      In `checkBlockLine` and `placeBlockLine`, `chunkX`/`chunkZ` were already
      chunk coordinates (`coord >> 4`) but were shifted **again** before being
      passed to `getChunkFromChunkCoords`, fetching a chunk 16 chunks (256 blocks)
      away. That chunk is effectively never loaded during worldgen, so:
      - `placeBlockLine` aborted the **entire branch line** the moment it reached
        its unloaded-chunk guard (`return`), truncating branches and canopies.
      - `checkBlockLine` validated blocks in the wrong chunk, incorrectly
        failing/passing generation checks.

   2. **Mahogany vine generation was completely suppressed** by three compounding
      bugs introduced in the follow-up rewrites of `WorldGenTallTree`:
      - `canPlaceVines` required `blockAtPos == Blocks.vine` **and** air at the
        same position — an impossible condition, so it always returned `false`.
      - Candidate positions were sampled with `rand.nextInt(5)` when collected and
        then **again** when placed (1/25 effective rate instead of 1/5).
      - `generateVinesAt` accepted only sides facing *air*; vines can only attach
        to solid blocks (the original code used `canPlaceBlockOnSide`).

   ## Changes

   - `TCGenBase.checkBlockLine` / `placeBlockLine`: remove the erroneous second
     `>> 4` so the guards inspect the correct chunk.
   - `TCGenBase.placeBlockLine`: on an unloaded neighbor chunk, `continue` (skip
     only the affected blocks) instead of `return` (abort the whole line), so
     branch geometry is preserved while still avoiding cascading worldgen.
   - `WorldGenTallTree.canPlaceVines`: drop the contradictory vine-block check.
   - `WorldGenTallTree.placeVines`: sample the vine chance once (using the
     existing `VINE_CHANCE` constant) instead of twice.
   - `WorldGenTallTree.generateVinesAt`: restore `canPlaceBlockOnSide` as the
     attachment check; remove empty `else {}` and dead locals.
   - Remove leftover debug `System.out.println` calls (`"t2"`, `"watwat"`) and the
     dead `placedBlocks` set in `TCGenBase`.

   ## Testing

   - `./gradlew compileJava` — ✅
   - `./gradlew checkstyleMain` — ✅
   - `./gradlew spotlessCheck` — ✅
   - In-game: generate a fresh rainforest world and compare mahogany trees near
     chunk borders (F3+G) against the screenshots in #14. Canopies and branch
     lines should be full and symmetric as in TC 1.7, and vine clusters should
     appear at their intended density attached to log/leaf blocks.

   ## Note

   Shares the same breaking commit as #13/#19 but is otherwise unrelated to that
   fix; this can land independently (both touch `TCGenBase`, so rebase whichever
   merges second).

   Closes #14