### PR TITLE
Fix broken bamboo flower pot item icon and duplicate block/item registration (Fixes #4)

### DIFF
--- a/src/main/java/net/tropicraft/block/BlockTropicraftFlowerPot.java
+++ b/src/main/java/net/tropicraft/block/BlockTropicraftFlowerPot.java
@@ -14,7 +14,7 @@ import net.tropicraft.block.tileentity.TileEntityTropicraftFlowerPot;
 import net.tropicraft.factory.TileEntityFactory;
 import net.tropicraft.info.TCRenderIDs;
 import net.tropicraft.registry.TCBlockRegistry;
-import net.tropicraft.registry.TCItemRegistry;
+import net.tropicraft.registry.TCCreativeTabRegistry;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -23,6 +23,7 @@ public class BlockTropicraftFlowerPot extends BlockTropicraft implements ITileEn
 
     public BlockTropicraftFlowerPot() {
         super(Material.circuits);
+        this.setCreativeTab(TCCreativeTabRegistry.tabDecorations);
         this.setBlockTextureName("flowerPot");
         this.setBlockBoundsForItemRender();
     }
@@ -79,7 +80,7 @@ public class BlockTropicraftFlowerPot extends BlockTropicraft implements ITileEn
     @SideOnly(Side.CLIENT)
     public Item getItem(final World world, final int x, final int y, final int z) {
         final ItemStack var5 = getPlantForMeta(world.getBlockMetadata(x, y, z));
-        return (Item) ((var5 == null) ? TCItemRegistry.flowerPot : var5.getItem());
+        return (Item) ((var5 == null) ? Item.getItemFromBlock(this) : var5.getItem());
     }
 
     public boolean canPlaceBlockAt(final World par1World, final int par2, final int par3, final int par4) {

--- a/src/main/java/net/tropicraft/item/ItemFlowerPot.java
+++ b/src/main/java/net/tropicraft/item/ItemFlowerPot.java
@@ -2,15 +2,25 @@ package net.tropicraft.item;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
-import net.minecraft.item.ItemReed;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.util.IIcon;
 
-public class ItemFlowerPot extends ItemReed {
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public class ItemFlowerPot extends ItemBlock {
 
     public ItemFlowerPot(final Block block) {
         super(block);
     }
 
+    @SideOnly(Side.CLIENT)
     public void registerIcons(final IIconRegister registry) {
         this.itemIcon = registry.registerIcon("tropicraft:flowerPot");
+    }
+
+    @SideOnly(Side.CLIENT)
+    public IIcon getIconFromDamage(final int damage) {
+        return this.itemIcon;
     }
 }

--- a/src/main/java/net/tropicraft/registry/TCBlockRegistry.java
+++ b/src/main/java/net/tropicraft/registry/TCBlockRegistry.java
@@ -56,6 +56,7 @@ import net.tropicraft.block.BlockTropicsPortal;
 import net.tropicraft.block.BlockTropicsWater;
 import net.tropicraft.info.TCNames;
 import net.tropicraft.item.ItemBlockTropicraft;
+import net.tropicraft.item.ItemFlowerPot;
 import net.tropicraft.item.ItemPineapple;
 import net.tropicraft.item.ItemTallFlowers;
 import net.tropicraft.item.ItemTropicraftSlab;
@@ -157,7 +158,7 @@ public class TCBlockRegistry {
         registerBlock((Block) TCBlockRegistry.tropicsWater, "tropicsWater");
         registerBlock((Block) TCBlockRegistry.rainStopper, "rainStopper");
         registerMultiBlock((Block) TCBlockRegistry.flowers, "flower", TCNames.flowerIndices);
-        registerBlock((Block) TCBlockRegistry.flowerPot, "flowerPot");
+        registerBlock((Block) TCBlockRegistry.flowerPot, ItemFlowerPot.class, "flowerPot");
         registerBlock((Block) TCBlockRegistry.coconut, "coconut");
         registerBlock(TCBlockRegistry.firePit, "firePit");
         registerBlock((Block) TCBlockRegistry.bambooChest, "bambooChest");
@@ -198,6 +199,12 @@ public class TCBlockRegistry {
 
     private static void registerBlock(final Block block, final String name) {
         GameRegistry.registerBlock(block, "tile." + name);
+        block.setBlockName(name);
+    }
+
+    private static void registerBlock(final Block block, final Class<? extends ItemBlock> itemClass,
+        final String name) {
+        GameRegistry.registerBlock(block, itemClass, "tile." + name);
         block.setBlockName(name);
     }
 

--- a/src/main/java/net/tropicraft/registry/TCCraftingRegistry.java
+++ b/src/main/java/net/tropicraft/registry/TCCraftingRegistry.java
@@ -182,7 +182,8 @@ public class TCCraftingRegistry {
         Tropicraft.encyclopedia.includeItem("fishingnet", new ItemStack((Item) TCItemRegistry.fishingNet));
         Tropicraft.encyclopedia.includeItem("flippers", new ItemStack(TCItemRegistry.flippers));
         Tropicraft.encyclopedia.includeItem("flippers", new ItemStack(Items.leather));
-        Tropicraft.encyclopedia.includeItem("flowerpot", new ItemStack((Item) TCItemRegistry.flowerPot));
+        Tropicraft.encyclopedia
+            .includeItem("flowerpot", new ItemStack(Item.getItemFromBlock(TCBlockRegistry.flowerPot)));
         Tropicraft.encyclopedia.includeItem("froglegs", new ItemStack((Item) TCItemRegistry.frogLeg));
         Tropicraft.encyclopedia.includeItem("froglegscooked", new ItemStack((Item) TCItemRegistry.cookedFrogLeg));
         Tropicraft.encyclopedia.includeItem("frogskin", new ItemStack((Item) TCItemRegistry.poisonFrogSkin));
@@ -585,7 +586,7 @@ public class TCCraftingRegistry {
             new Object[] { "  X", "XX ", "XX ", 'X', Items.string });
         createRecipe(
             true,
-            new ItemStack((Item) TCItemRegistry.flowerPot),
+            new ItemStack(Item.getItemFromBlock(TCBlockRegistry.flowerPot)),
             new Object[] { "# #", " # ", '#', TCItemRegistry.bambooChute });
         createRecipe(
             true,

--- a/src/main/java/net/tropicraft/registry/TCItemRegistry.java
+++ b/src/main/java/net/tropicraft/registry/TCItemRegistry.java
@@ -20,7 +20,6 @@ import net.tropicraft.item.ItemDartGun;
 import net.tropicraft.item.ItemFertilizer;
 import net.tropicraft.item.ItemFishBucket;
 import net.tropicraft.item.ItemFlippers;
-import net.tropicraft.item.ItemFlowerPot;
 import net.tropicraft.item.ItemMobEgg;
 import net.tropicraft.item.ItemPortalEnchanter;
 import net.tropicraft.item.ItemShell;
@@ -110,7 +109,6 @@ public class TCItemRegistry {
     public static final ItemFishBucket fishBucket;
     public static final ItemChair chair;
     public static final ItemUmbrella umbrella;
-    public static final ItemFlowerPot flowerPot;
     public static final ItemFertilizer fertilizer;
     public static final ItemTropicraft coconutBomb;
     public static final ItemCurare curare;
@@ -184,7 +182,6 @@ public class TCItemRegistry {
         registerItem((Item) TCItemRegistry.bucketTropicsWater, "bucketTropicsWater");
         registerItem((Item) TCItemRegistry.chair, "chair");
         registerItem((Item) TCItemRegistry.umbrella, "umbrella");
-        registerItem((Item) TCItemRegistry.flowerPot, "flowerPot");
         registerItem((Item) TCItemRegistry.fertilizer, "fertilizer");
         registerItem((Item) TCItemRegistry.curare, "curare");
         registerItem((Item) TCItemRegistry.dart, "dart");
@@ -319,7 +316,6 @@ public class TCItemRegistry {
         fishBucket = new ItemFishBucket();
         chair = new ItemChair();
         umbrella = new ItemUmbrella();
-        flowerPot = new ItemFlowerPot((Block) TCBlockRegistry.flowerPot);
         fertilizer = new ItemFertilizer();
         coconutBomb = (ItemTropicraft) new ItemCoconutBomb().setMaxStackSize(64);
         curare = new ItemCurare();


### PR DESCRIPTION
## Summary

   Fixes #4 — the bamboo flower pot's item icon was broken (missing texture) in the
   creative menu, and the block variant was showing in the Building Blocks tab
   instead of the proper item. The flower pot is now registered the vanilla 1.7.10
   way: a single block with a single custom `ItemBlock`, appearing in the
   **Decorations** creative tab with the correct `items/flowerPot.png` icon.

   ## Root cause

   Two defects combined:

   1. **Phantom auto-`ItemBlock` with a broken icon.** `TCBlockRegistry` registered
      the pot via `GameRegistry.registerBlock(block, "tile.flowerPot")`, which makes
      FML auto-generate an `ItemBlock` under the key `tropicraft:tile.flowerPot`.
      Because `BlockTropicraft` assigns the Building Blocks tab, the phantom showed
      up there, and its icon was broken: `ItemBlock.registerIcons()` registers
      `block.getItemIconName()` = `"flowerPot"` with **no domain**, so it resolved
      to `minecraft:items/flowerPot` (missing texture).

   2. **The real item never replaced the phantom.** The custom `ItemFlowerPot`
      (an `ItemReed` subclass) was registered separately via
      `GameRegistry.registerItem(..., "flowerPot")` → key `tropicraft:flowerPot`,
      which does **not** match the block's `tropicraft:tile.flowerPot` key. Both
      items coexisted in the registry, and since the item set no creative tab it
      appeared in no tab at all.

   ## Fix

   - **`ItemFlowerPot.java`** — now extends `ItemBlock` (required for
     `registerBlock`'s item-class registration). Keeps the `registerIcons` override
     and adds `getIconFromDamage()` so the item renders `tropicraft:flowerPot`
     (`items/flowerPot.png`) instead of the block-texture fallback.
   - **`TCBlockRegistry.java`** — the pot block is now registered **with its
     custom item class**, so FML creates exactly one item at the block's id — the
     phantom auto-`ItemBlock` no longer exists. Added a small
     `registerBlock(block, itemClass, name)` helper preserving the existing
     "tile." prefix convention (which also satisfies FML's block↔item
     `verifyItemBlockName` check).
   - **`BlockTropicraftFlowerPot.java`** — creative tab changed from the inherited
     `tabBlock` to `tabDecorations` (vanilla convention for pots; `ItemBlock`
     forwards `getCreativeTab()` to the block's tab). Pick-block (`getItem`) now
     returns `Item.getItemFromBlock(this)`.
   - **`TCItemRegistry.java`** — removed the duplicate `flowerPot` field/registration
     entirely (it registered a second item under a mismatched key — the core bug).
   - **`TCCraftingRegistry.java`** — encyclopedia entry and the pot recipe now use
     `Item.getItemFromBlock(TCBlockRegistry.flowerPot)`.

   ## Verification

   - `./gradlew compileJava` — passes (only pre-existing deprecation/unchecked notes)
   - `./gradlew spotlessJavaCheck` — passes
   - Client QA (all confirmed working):
     - Pot appears in the Decorations tab with a proper icon; no broken entry in
       Building Blocks.
     - `/give @p tropicraft:tile.flowerPot` returns the item with the correct icon.
     - Placing, planting flowers, and pick-blocking work.
     - Breaking a planted pot drops pot + plant.
     - Crafting recipe and Encyclopedia Tropica entry still function.

   ## Upgrade note

   The pot item's registry name is unified to `tropicraft:tile.flowerPot`
   (matching every other Tropicraft block). Worlds saved on older builds will show
   a **one-time** FML missing-mapping notice for the removed duplicate
   `tropicraft:flowerPot` entry. Placed flower pots in existing worlds are
   unaffected (the block's name/ID is unchanged); any pot *items* stored in
   containers from an old build should simply be re-crafted.

Closes #4 