### PR TITLE
Fix tropical fish animating in slow motion while flopping on land (Fixes #7)

### DIFF
--- a/src/main/java/net/tropicraft/client/entity/model/ModelFish.java
+++ b/src/main/java/net/tropicraft/client/entity/model/ModelFish.java
@@ -8,6 +8,7 @@ public class ModelFish extends ModelBase {
 
     public ModelRenderer Body;
     public ModelRenderer Tail;
+    public boolean inWater;
 
     public ModelFish() {
         this.setTextureOffset("Body.Body", 0, 0);
@@ -29,6 +30,10 @@ public class ModelFish extends ModelBase {
     public void setRotationAngles(final float f, final float f1, final float f2, final float f3, final float f4,
         final float f5, final Entity ent) {
         super.setRotationAngles(f, f1, f2, f3, f4, f5, ent);
-        this.Tail.rotateAngleY = (float) Math.sin(f2 * 0.25f) * 0.25f;
+        if (!this.inWater) {
+            this.Tail.rotateAngleY = (float) Math.sin(f2 * 0.55f) * 0.26f;
+        } else {
+            this.Tail.rotateAngleY = (float) Math.sin(f2 * 0.25f) * 0.25f;
+        }
     }
 }

--- a/src/main/java/net/tropicraft/client/entity/render/RenderTropicalFish.java
+++ b/src/main/java/net/tropicraft/client/entity/render/RenderTropicalFish.java
@@ -29,6 +29,7 @@ public class RenderTropicalFish extends RenderWaterMob {
 
     public void renderTropicalFish(final EntityTropicalFish fish, final double d, final double d1, final double d2,
         final float f, final float f1) {
+        this.fish.inWater = fish.isInWater();
         super.renderWaterMob(fish, d, d1, d2, f, f1);
     }
 


### PR DESCRIPTION
## Problem

When a tropical fish is out of the water, it plays its tail-wag animation at the same slow rate used for swimming, making the flopping look like it is happening in slow motion. Flopping on land is intended behavior — only the animation speed is wrong.

## Root cause

`ModelFish.setRotationAngles` wags the tail unconditionally with the swimming sway:

```java
this.Tail.rotateAngleY = (float) Math.sin(f2 * 0.25f) * 0.25f;
```

At 20 ticks/second, `sin(t * 0.25)` completes a full tail sweep roughly every 25 ticks (~1.26s), which reads as a gentle swim sway underwater but looks like slow-motion thrashing when the fish is beached on its side.

## Fix

This mirrors the pattern `ModelMarlin` already uses (its `inWater` flag with a dedicated land branch), keeping everything consistent across fish models:

- **`ModelFish`**: added an `inWater` flag and a land branch to `setRotationAngles`. On land the tail now thrashes with the marlin's exact land values — `sin(f2 * 0.55f) * 0.26f` (~2.2x faster rate, slightly stronger swing). In water the original `sin(f2 * 0.25f) * 0.25f` swim animation is unchanged.
- **`RenderTropicalFish`**: sets `fish.inWater = fish.isInWater()` at the start of `renderTropicalFish`, exactly like `RenderMarlin` does for its model.

No entity logic or hop physics were touched — this is a client-side animation fix only.

## Affected-entity audit

Checked all water mobs for the same bug pattern:

| Model                      | Status                                         |
| -------------------------- | ---------------------------------------------- |
| `ModelFish` (tropical fish) | Had the bug — fixed in this PR                 |
| `ModelMarlin`              | Already correct (reference pattern)            |
| `ModelManOWar`             | Already handles land via `isOnGround` flag     |
| `ModelSeahorse`            | Uses `limbSwing`-driven animation, not affected |
| `ModelEagleRay`            | Uses entity-tick wing cycle, not affected      |

## Testing

- `gradlew compileJava` — builds successfully
- `gradlew checkstyleMain spotlessCheck` — pass
- Spawned a tropical fish on land: tail now thrashes at a natural speed; swimming animation in water is unchanged

Closes #7 