### PR TITLE
Fix player model offset when sitting on Tropicraft chairs (Fixes #6)

### DIFF
--- a/src/main/java/net/tropicraft/entity/placeable/EntityChair.java
+++ b/src/main/java/net/tropicraft/entity/placeable/EntityChair.java
@@ -370,12 +370,12 @@ public class EntityChair extends Entity {
 
     public void updateRiderPosition() {
         if (this.riddenByEntity != null) {
-            final double xOffset = Math.cos(this.rotationYaw * 3.141592653589793 / 180.0) * 0.4;
-            final double zOffset = Math.sin(this.rotationYaw * 3.141592653589793 / 180.0) * 0.4;
+            // Center the rider on the seat. Unlike the vanilla boat this entity was based on,
+            // the chair's seat is centered on the entity origin, so no horizontal offset is needed.
             this.riddenByEntity.setPosition(
-                this.posX + xOffset,
+                this.posX,
                 this.posY + this.getMountedYOffset() + this.riddenByEntity.getYOffset(),
-                this.posZ + zOffset);
+                this.posZ);
         }
     }
 


### PR DESCRIPTION
## Summary

When a player sat on a Tropicraft beach chair (`EntityChair`), their model was visibly displaced from the seat — offset to the side/front of the chair instead of sitting centered on the cushion. This PR removes the erroneous horizontal rider offset so the player model sits perfectly centered on the seat.

## Root cause

`EntityChair` was originally written as a near-verbatim copy of vanilla 1.7.10 `EntityBoat`, and it inherited the boat's rider positioning logic in `updateRiderPosition()`:

```java
final double xOffset = Math.cos(this.rotationYaw * Math.PI / 180.0) * 0.4;
final double zOffset = Math.sin(this.rotationYaw * Math.PI / 180.0) * 0.4;
this.riddenByEntity.setPosition(this.posX + xOffset, ..., this.posZ + zOffset);
```

On a boat, this 0.4-block offset deliberately pushes the rider toward the boat's side/front to match the boat model. The chair, however, has its seat centered on the entity origin (`ModelChair.seat` spans roughly -8..8 pixels on both axes), so the offset pushed the rider off the seat entirely — producing the misalignment reported in #6.

## Changes

- `EntityChair.updateRiderPosition()` — removed the boat-inherited 0.4-block horizontal offset. The rider is now placed at the chair's exact X/Z position, keeping the existing vertical offset (`getMountedYOffset()`), which is unchanged and still correct.

## Notes / intentionally not changed

- **Chair facing:** `RenderChair` renders the model with a mirrored yaw (`f + (180 - f) * 2` instead of the vanilla `180 - f`), which makes the chair visually face the player who placed it. This is long-standing, purely cosmetic behavior and has no functional impact now that the rider is centered, so it was left as-is.
- **Rider height:** `getMountedYOffset()` (`height - 0.65`) is acceptable as-is.

## Testing

- `gradlew compileJava` — BUILD SUCCESSFUL
- `gradlew checkstyleMain` — BUILD SUCCESSFUL
- Manual in-game check: place a chair, right-click to sit — the player model is now centered on the seat cushion regardless of the chair's orientation.

Closes #6 