### PR TITLE
Fix missing localization for some item/block names (Fixes #28)

### DIFF
--- a/src/main/resources/assets/tropicraft/lang/en_US.lang
+++ b/src/main/resources/assets/tropicraft/lang/en_US.lang
@@ -91,6 +91,11 @@ tile.tropicraft:bambooChute.name=Bamboo Chute
 tile.tropicraft:koaChest.name=Koa Chest
 tile.tropicraft:purchasePlate.name=Koa Trader Purchase Plate
 tile.tropicraft:eihMixer.name=Drink Mixer
+tile.tropicraft:rainStopper.name=Rain Stopper
+
+# Unprefixed block localizations (blocks extending vanilla classes)
+tile.bambooDoor.name=Bamboo Door
+tile.bambooMug.name=Bamboo Mug
 
 # Item localizations
 item.tropicraft:frogLeg.name=Frog Leg
@@ -116,6 +121,9 @@ item.tropicraft:ore_Zirconium.name=Zirconium Crystal
 item.tropicraft:ore_SmeltedZircon.name=Smelted Zircon Crystal
 item.tropicraft:waterWand.name=Water Wand
 item.tropicraft:fishingNet.name=Fishing Net
+
+# Unprefixed item localizations (items extending non-Tropicraft classes)
+item.fishingRodTropical.name=Tropical Fishing Rod
 item.tropicraft:coffeeBean_Berry.name=Coffee Berry
 item.tropicraft:coffeeBean_Raw.name=Raw Coffee Bean
 item.tropicraft:coffeeBean_Roasted.name=Roasted Coffee Bean


### PR DESCRIPTION
## Summary

Not all items/blocks in the mod had localization entries (issue #28). This PR adds the missing entries to `en_US.lang` and documents which keys are intentionally unprefixed.

## Root cause

Since Forge 1.7.10 does not auto-prefix unlocalized names with the modid, this mod's own base classes construct the `tropicraft:` prefix manually:

- `BlockTropicraft.getUnlocalizedName()` → `tile.tropicraft:<name>` → key `tile.tropicraft:<name>.name`
- `ItemTropicraft.getUnlocalizedName()` → `item.tropicraft:<name>` → key `item.tropicraft:<name>.name`

Cross-checking every `registerBlock`/`registerMultiBlock`/`registerItem` call (including all multi-variant arrays in `TCNames`) against `en_US.lang` surfaced one real user-visible gap plus a few items/blocks whose classes extend vanilla (non-Tropicraft) base classes and therefore resolve to *unprefixed* keys.

## Changes

**`src/main/resources/assets/tropicraft/lang/en_US.lang`** (4 new entries + 2 section comments)

| Key | Value | Note |
|---|---|---|
| `tile.tropicraft:rainStopper.name` | Rain Stopper | The reported gap. `BlockRainStopper` extends `BlockTropicraft` (prefixed key) and sits in the creative Blocks tab, so it previously showed the raw unlocalized key |
| `item.fishingRodTropical.name` | Tropical Fishing Rod | Unprefixed key: `ItemTropicalFishingRod` is CoroUtil's class extending vanilla `Item` (held by Koa Fishers) |
| `tile.bambooDoor.name` | Bamboo Door | Unprefixed key: `BlockBambooDoor` extends `BlockDoor` with no `getUnlocalizedName` override |
| `tile.bambooMug.name` | Bamboo Mug | Unprefixed key: `BlockBambooMug` extends `BlockContainer` with no `getUnlocalizedName` override |

Added `# Unprefixed block localizations` / `# Unprefixed item localizations` comment groups so the missing `tropicraft:` prefix on those three lines is intentional and documented (the in-world tiles are not shown to players; only the item variants, which are already localized, are visible).

## Verification

- All other registered entries verified present: mob eggs (`egg_*`), ore/shell/pearl/coffee variants, slabs (`singleSlabs_*`), 16 chair/umbrella colors, records, and the pineapple block (its key resolves via `BlockPineapple`'s hard-coded `tallFlower` override to the existing `tile.tropicraft:tallFlower_Pineapple.name`).
- `./gradlew build` passes (compile, Spotless, Checkstyle).

Closes #28