### PR TITLE
Fix crippling worldgen lag while restoring pre-REUP worldgen accuracy

### DIFF
--- a/src/main/java/net/tropicraft/Tropicraft.java
+++ b/src/main/java/net/tropicraft/Tropicraft.java
@@ -22,6 +22,7 @@ import net.tropicraft.registry.TCTileEntityRegistry;
 import net.tropicraft.util.ColorHelper;
 import net.tropicraft.util.TropicraftWorldUtils;
 import net.tropicraft.world.TCWorldGenerator;
+import net.tropicraft.world.chunk.ChunkProviderTropicraft;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
@@ -31,6 +32,8 @@ import cpw.mods.fml.common.event.FMLInterModComms;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
+import cpw.mods.fml.common.event.FMLServerStoppingEvent;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.network.FMLEventChannel;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -90,6 +93,17 @@ public class Tropicraft {
         FMLCommonHandler.instance()
             .bus()
             .register(misc);
+        // FMLServerStoppingEvent is an FMLEvent, not a Forge Event, so it can only live on the FML bus.
+        // It fires before the final world save, letting us flush deferred decorations to disk.
+        FMLCommonHandler.instance()
+            .bus()
+            .register(new Object() {
+
+                @SubscribeEvent
+                public void onServerStopping(final FMLServerStoppingEvent event) {
+                    ChunkProviderTropicraft.flushAllProvidersForSave();
+                }
+            });
         GameRegistry.registerWorldGenerator(new TCWorldGenerator(), 10);
         TropicraftWorldUtils.initializeDimension();
     }

--- a/src/main/java/net/tropicraft/Tropicraft.java
+++ b/src/main/java/net/tropicraft/Tropicraft.java
@@ -33,7 +33,6 @@ import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.event.FMLServerStoppingEvent;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.network.FMLEventChannel;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -93,19 +92,15 @@ public class Tropicraft {
         FMLCommonHandler.instance()
             .bus()
             .register(misc);
-        // FMLServerStoppingEvent is an FMLEvent, not a Forge Event, so it can only live on the FML bus.
-        // It fires before the final world save, letting us flush deferred decorations to disk.
-        FMLCommonHandler.instance()
-            .bus()
-            .register(new Object() {
-
-                @SubscribeEvent
-                public void onServerStopping(final FMLServerStoppingEvent event) {
-                    ChunkProviderTropicraft.flushAllProvidersForSave();
-                }
-            });
         GameRegistry.registerWorldGenerator(new TCWorldGenerator(), 10);
         TropicraftWorldUtils.initializeDimension();
+    }
+
+    @Mod.EventHandler
+    public void serverStopping(final FMLServerStoppingEvent event) {
+        // Fires before the final world save: flush deferred decorations so no chunk is saved
+        // with terrain but without its decorations.
+        ChunkProviderTropicraft.flushAllProvidersForSave();
     }
 
     @Mod.EventHandler

--- a/src/main/java/net/tropicraft/event/TCMiscEvents.java
+++ b/src/main/java/net/tropicraft/event/TCMiscEvents.java
@@ -13,6 +13,7 @@ import net.minecraftforge.event.world.WorldEvent;
 import net.tropicraft.entity.placeable.EntityChair;
 import net.tropicraft.util.EffectHelper;
 import net.tropicraft.util.TropicraftWorldUtils;
+import net.tropicraft.world.chunk.ChunkProviderTropicraft;
 
 import CoroUtil.forge.CoroAI;
 import CoroUtil.world.WorldDirector;
@@ -25,6 +26,12 @@ import cpw.mods.fml.relauncher.SideOnly;
 import extendedrenderer.ExtendedRenderer;
 
 public class TCMiscEvents {
+
+    @SubscribeEvent
+    public void serverStopping(final cpw.mods.fml.common.event.FMLServerStoppingEvent event) {
+        // Fires before the final world save, so pending decorations are applied before chunks hit disk.
+        ChunkProviderTropicraft.flushAllProvidersForSave();
+    }
 
     @SubscribeEvent
     public void worldLoad(final WorldEvent.Load event) {

--- a/src/main/java/net/tropicraft/event/TCMiscEvents.java
+++ b/src/main/java/net/tropicraft/event/TCMiscEvents.java
@@ -13,7 +13,6 @@ import net.minecraftforge.event.world.WorldEvent;
 import net.tropicraft.entity.placeable.EntityChair;
 import net.tropicraft.util.EffectHelper;
 import net.tropicraft.util.TropicraftWorldUtils;
-import net.tropicraft.world.chunk.ChunkProviderTropicraft;
 
 import CoroUtil.forge.CoroAI;
 import CoroUtil.world.WorldDirector;
@@ -26,12 +25,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 import extendedrenderer.ExtendedRenderer;
 
 public class TCMiscEvents {
-
-    @SubscribeEvent
-    public void serverStopping(final cpw.mods.fml.common.event.FMLServerStoppingEvent event) {
-        // Fires before the final world save, so pending decorations are applied before chunks hit disk.
-        ChunkProviderTropicraft.flushAllProvidersForSave();
-    }
 
     @SubscribeEvent
     public void worldLoad(final WorldEvent.Load event) {

--- a/src/main/java/net/tropicraft/world/TeleporterTropics.java
+++ b/src/main/java/net/tropicraft/world/TeleporterTropics.java
@@ -75,6 +75,12 @@ public class TeleporterTropics extends Teleporter {
             for (int x = entityX - searchArea; x <= entityX + searchArea; ++x) {
                 final double distX = x + 0.5 - entity.posX;
                 for (int z = entityZ - searchArea; z <= entityZ + searchArea; ++z) {
+                    // Only scan already-generated chunks. Probing an ungenerated chunk would synchronously
+                    // generate it (cascading worldgen) - the cause of the multi-second freeze on dimension entry.
+                    if (!this.world.getChunkProvider()
+                        .chunkExists(x >> 4, z >> 4)) {
+                        continue;
+                    }
                     final double distZ = z + 0.5 - entity.posZ;
                     for (int y = this.world.getActualHeight() - 1; y >= 0; --y) {
                         if (this.world.getBlock(x, y, z) == TeleporterTropics.PORTAL_BLOCK) {
@@ -184,6 +190,10 @@ public class TeleporterTropics extends Teleporter {
         for (int x = entityX - searchArea; x <= entityX + searchArea; ++x) {
             final double distX = x + 0.5 - entity.posX;
             Label_0418: for (int z = entityZ - searchArea; z <= entityZ + searchArea; ++z) {
+                if (!this.world.getChunkProvider()
+                    .chunkExists(x >> 4, z >> 4)) {
+                    continue;
+                }
                 final double distZ = z + 0.5 - entity.posZ;
                 int y;
                 for (y = this.world.getHeight() - 1; y >= 62
@@ -234,6 +244,12 @@ public class TeleporterTropics extends Teleporter {
     }
 
     public int getTerrainHeightAt(final int x, final int z) {
+        if (!this.world.getChunkProvider()
+            .chunkExists(x >> 4, z >> 4)) {
+            // Column not generated yet; fall back to sea level so portal placement never triggers
+            // cascading chunk generation on first entry to the dimension.
+            return 64;
+        }
         for (int y = 100; y > 0; --y) {
             final Block block = this.world.getBlock(x, y, z);
             if (block == Blocks.dirt || block == Blocks.grass

--- a/src/main/java/net/tropicraft/world/biomes/BiomeGenRainforest.java
+++ b/src/main/java/net/tropicraft/world/biomes/BiomeGenRainforest.java
@@ -38,8 +38,12 @@ public class BiomeGenRainforest extends BiomeGenTropicraft {
             new WorldGenHomeTree(world, rand).generate(xx, 0, zz);
         }
         if (rand.nextInt(70) == 0) {
+            // Note: the original (pre-REUP) code passed randCoord(rand, x, 16) for the Z coordinate too,
+            // which placed the altar at a location derived from the chunk's X - potentially 20+ chunks
+            // away from the chunk being decorated, where it could reach ungenerated chunks (cascading
+            // worldgen). Use z here so the altar generates inside the chunk it was rolled for.
             new WorldGenForestAltarRuin(world, rand)
-                .generate(this.randCoord(rand, x, 16), 0, this.randCoord(rand, x, 16));
+                .generate(this.randCoord(rand, x, 16), 0, this.randCoord(rand, z, 16));
         }
         if (rand.nextInt(2) == 0) {
             final int i = this.randCoord(rand, x, 16);

--- a/src/main/java/net/tropicraft/world/biomes/BiomeGenTropicraft.java
+++ b/src/main/java/net/tropicraft/world/biomes/BiomeGenTropicraft.java
@@ -1,18 +1,44 @@
 package net.tropicraft.world.biomes;
 
-import java.util.*;
+import java.util.Random;
 
-import net.minecraft.block.*;
-import net.minecraft.init.*;
-import net.minecraft.world.*;
-import net.minecraft.world.biome.*;
-import net.minecraft.world.gen.feature.*;
-import net.tropicraft.config.*;
-import net.tropicraft.entity.hostile.*;
-import net.tropicraft.entity.passive.*;
-import net.tropicraft.entity.underdasea.*;
-import net.tropicraft.registry.*;
-import net.tropicraft.world.worldgen.*;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraft.world.gen.feature.WorldGenTallGrass;
+import net.tropicraft.config.ConfigBiomes;
+import net.tropicraft.entity.hostile.EntityAshenHunter;
+import net.tropicraft.entity.hostile.EntityEIH;
+import net.tropicraft.entity.hostile.EntityTreeFrogBlue;
+import net.tropicraft.entity.hostile.EntityTreeFrogRed;
+import net.tropicraft.entity.hostile.EntityTreeFrogYellow;
+import net.tropicraft.entity.hostile.EntityTropiCreeper;
+import net.tropicraft.entity.hostile.EntityTropiSkeleton;
+import net.tropicraft.entity.hostile.SpiderAdult;
+import net.tropicraft.entity.passive.EntityIguana;
+import net.tropicraft.entity.passive.EntityTreeFrogGreen;
+import net.tropicraft.entity.passive.Failgull;
+import net.tropicraft.entity.passive.VMonkey;
+import net.tropicraft.entity.underdasea.EntityEagleRay;
+import net.tropicraft.entity.underdasea.EntityManOWar;
+import net.tropicraft.entity.underdasea.EntityMarlin;
+import net.tropicraft.entity.underdasea.EntitySeaTurtle;
+import net.tropicraft.entity.underdasea.EntitySeaUrchin;
+import net.tropicraft.entity.underdasea.EntitySeahorse;
+import net.tropicraft.entity.underdasea.EntityStarfish;
+import net.tropicraft.entity.underdasea.EntityTropicalFish;
+import net.tropicraft.registry.TCBlockRegistry;
+import net.tropicraft.world.worldgen.WorldGenBamboo;
+import net.tropicraft.world.worldgen.WorldGenCoral;
+import net.tropicraft.world.worldgen.WorldGenEIH;
+import net.tropicraft.world.worldgen.WorldGenSunkenShip;
+import net.tropicraft.world.worldgen.WorldGenTallFlower;
+import net.tropicraft.world.worldgen.WorldGenTropicraftCurvedPalm;
+import net.tropicraft.world.worldgen.WorldGenTropicraftFlowers;
+import net.tropicraft.world.worldgen.WorldGenTropicraftLargePalmTrees;
+import net.tropicraft.world.worldgen.WorldGenTropicraftNormalPalms;
+import net.tropicraft.world.worldgen.WorldGenWaterfall;
 
 public class BiomeGenTropicraft extends BiomeGenBase {
 

--- a/src/main/java/net/tropicraft/world/biomes/BiomeGenTropicraft.java
+++ b/src/main/java/net/tropicraft/world/biomes/BiomeGenTropicraft.java
@@ -1,43 +1,18 @@
 package net.tropicraft.world.biomes;
 
-import java.util.Random;
+import java.util.*;
 
-import net.minecraft.block.Block;
-import net.minecraft.init.Blocks;
-import net.minecraft.world.World;
-import net.minecraft.world.biome.BiomeGenBase;
-import net.tropicraft.config.ConfigBiomes;
-import net.tropicraft.entity.hostile.EntityAshenHunter;
-import net.tropicraft.entity.hostile.EntityEIH;
-import net.tropicraft.entity.hostile.EntityTreeFrogBlue;
-import net.tropicraft.entity.hostile.EntityTreeFrogRed;
-import net.tropicraft.entity.hostile.EntityTreeFrogYellow;
-import net.tropicraft.entity.hostile.EntityTropiCreeper;
-import net.tropicraft.entity.hostile.EntityTropiSkeleton;
-import net.tropicraft.entity.hostile.SpiderAdult;
-import net.tropicraft.entity.passive.EntityIguana;
-import net.tropicraft.entity.passive.EntityTreeFrogGreen;
-import net.tropicraft.entity.passive.Failgull;
-import net.tropicraft.entity.passive.VMonkey;
-import net.tropicraft.entity.underdasea.EntityEagleRay;
-import net.tropicraft.entity.underdasea.EntityManOWar;
-import net.tropicraft.entity.underdasea.EntityMarlin;
-import net.tropicraft.entity.underdasea.EntitySeaTurtle;
-import net.tropicraft.entity.underdasea.EntitySeaUrchin;
-import net.tropicraft.entity.underdasea.EntitySeahorse;
-import net.tropicraft.entity.underdasea.EntityStarfish;
-import net.tropicraft.entity.underdasea.EntityTropicalFish;
-import net.tropicraft.registry.TCBlockRegistry;
-import net.tropicraft.world.worldgen.WorldGenBamboo;
-import net.tropicraft.world.worldgen.WorldGenCoral;
-import net.tropicraft.world.worldgen.WorldGenEIH;
-import net.tropicraft.world.worldgen.WorldGenSunkenShip;
-import net.tropicraft.world.worldgen.WorldGenTallFlower;
-import net.tropicraft.world.worldgen.WorldGenTropicraftCurvedPalm;
-import net.tropicraft.world.worldgen.WorldGenTropicraftFlowers;
-import net.tropicraft.world.worldgen.WorldGenTropicraftLargePalmTrees;
-import net.tropicraft.world.worldgen.WorldGenTropicraftNormalPalms;
-import net.tropicraft.world.worldgen.WorldGenWaterfall;
+import net.minecraft.block.*;
+import net.minecraft.init.*;
+import net.minecraft.world.*;
+import net.minecraft.world.biome.*;
+import net.minecraft.world.gen.feature.*;
+import net.tropicraft.config.*;
+import net.tropicraft.entity.hostile.*;
+import net.tropicraft.entity.passive.*;
+import net.tropicraft.entity.underdasea.*;
+import net.tropicraft.registry.*;
+import net.tropicraft.world.worldgen.*;
 
 public class BiomeGenTropicraft extends BiomeGenBase {
 
@@ -145,12 +120,8 @@ public class BiomeGenTropicraft extends BiomeGenBase {
         }
 
         if (rand.nextInt(4) == 0) {
-            terrainHeight = this.getTerrainHeightAt(world, i, k);
-            if (terrainHeight > 0 && world.isAirBlock(i, terrainHeight, k)) {
-                if (world.getBlock(i, terrainHeight - 1, k) == Blocks.grass) {
-                    world.setBlock(i, terrainHeight, k, Blocks.tallgrass, 1, 2);
-                }
-            }
+            new WorldGenTallGrass(Blocks.tallgrass, 1)
+                .generate(world, rand, i, this.getTerrainHeightAt(world, i, k), k);
         }
 
         for (int a = 0; a < 25; ++a) {

--- a/src/main/java/net/tropicraft/world/biomes/BiomeGenTropics.java
+++ b/src/main/java/net/tropicraft/world/biomes/BiomeGenTropics.java
@@ -27,8 +27,6 @@ public class BiomeGenTropics extends BiomeGenTropicraft {
 
         int i = this.randCoord(rand, x, 16);
         int k = this.randCoord(rand, z, 16);
-        int j = this.randCoord(rand, x, 16);
-        int l = this.randCoord(rand, z, 16);
 
         if (world.isAirBlock(i, this.getTerrainHeightAt(world, i, k), k)) {
             new WorldGenTropicraftFlowers(world, rand, TCBlockRegistry.flowers, BiomeGenTropics.DEFAULT_FLOWER_META)
@@ -36,9 +34,9 @@ public class BiomeGenTropics extends BiomeGenTropicraft {
         }
 
         if (rand.nextInt(2) == 0) {
-            final int treeType = new Random((long) (j >> 2) << 32 | (l >> 2)).nextInt(4);
-            j = this.randCoord(rand, x, 16);
-            l = this.randCoord(rand, z, 16);
+            final int treeType = new Random((long) (x >> 2) << 32 | (z >> 2)).nextInt(4);
+            final int j = this.randCoord(rand, x, 16);
+            final int l = this.randCoord(rand, z, 16);
             new WorldGenTropicraftFruitTrees(world, rand, treeType)
                 .generate(j, this.getTerrainHeightAt(world, j, l), l);
         }

--- a/src/main/java/net/tropicraft/world/chunk/ChunkProviderTropicraft.java
+++ b/src/main/java/net/tropicraft/world/chunk/ChunkProviderTropicraft.java
@@ -1,7 +1,10 @@
 package net.tropicraft.world.chunk;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockSand;
@@ -9,12 +12,15 @@ import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.IProgressUpdate;
 import net.minecraft.util.MathHelper;
+import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.ChunkPosition;
 import net.minecraft.world.SpawnerAnimals;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.gen.ChunkProviderServer;
 import net.minecraft.world.gen.NoiseGeneratorOctaves;
 import net.minecraft.world.gen.feature.WorldGenMinable;
 import net.minecraft.world.gen.feature.WorldGenerator;
@@ -47,6 +53,14 @@ public class ChunkProviderTropicraft implements IChunkProvider {
     private WorldGenerator coalGen;
     private WorldGenerator lapisGen;
     private float[] parabolicField;
+    /**
+     * Radius (in chunks) of the neighborhood that must be fully loaded before a chunk's decorations are applied.
+     * This guarantees that every block read/write performed by decoration (trees, villages, etc.) lands in an
+     * already-generated chunk, eliminating cascading chunk generation while keeping worldgen fully accurate.
+     */
+    private static final int DECOR_RADIUS = 3;
+    /** Chunks whose terrain is generated but whose decorations are deferred until their neighborhood is loaded. */
+    private final Set<ChunkCoordIntPair> pendingDecoration = new HashSet<>();
 
     public ChunkProviderTropicraft(final World worldObj, final long seed, final boolean par4) {
         this.worldObj = worldObj;
@@ -340,6 +354,19 @@ public class ChunkProviderTropicraft implements IChunkProvider {
     }
 
     public void populate(final IChunkProvider par1IChunkProvider, final int i, final int j) {
+        final ChunkCoordIntPair key = new ChunkCoordIntPair(i, j);
+        if (!this.isAreaLoaded(i, j, DECOR_RADIUS)) {
+            // Defer decoration until the whole neighborhood this chunk's features can touch is generated.
+            // This is what prevents cascading chunk generation without clipping any worldgen.
+            this.pendingDecoration.add(key);
+            return;
+        }
+        this.pendingDecoration.remove(key);
+        this.doPopulate(i, j);
+        this.flushPending();
+    }
+
+    private void doPopulate(final int i, final int j) {
         BlockSand.fallInstantly = true;
         final int x = i * 16;
         final int z = j * 16;
@@ -353,6 +380,34 @@ public class ChunkProviderTropicraft implements IChunkProvider {
         this.generateOres(x, z);
         SpawnerAnimals.performWorldGenSpawning(this.worldObj, biome, x + 8, z + 8, 16, 16, this.rand);
         BlockSand.fallInstantly = false;
+        this.worldObj.getChunkFromChunkCoords(i, j)
+            .setChunkModified();
+    }
+
+    private boolean isAreaLoaded(final int cx, final int cz, final int radius) {
+        final IChunkProvider provider = this.worldObj.getChunkProvider();
+        for (int dx = -radius; dx <= radius; ++dx) {
+            for (int dz = -radius; dz <= radius; ++dz) {
+                if (!provider.chunkExists(cx + dx, cz + dz)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private void flushPending() {
+        boolean progress;
+        do {
+            progress = false;
+            for (final ChunkCoordIntPair key : new ArrayList<>(this.pendingDecoration)) {
+                if (this.isAreaLoaded(key.chunkXPos, key.chunkZPos, DECOR_RADIUS)) {
+                    this.pendingDecoration.remove(key);
+                    this.doPopulate(key.chunkXPos, key.chunkZPos);
+                    progress = true;
+                }
+            }
+        } while (progress);
     }
 
     public void generateOres(final int x, final int z) {
@@ -411,7 +466,45 @@ public class ChunkProviderTropicraft implements IChunkProvider {
     }
 
     public boolean unloadQueuedChunks() {
+        if (this.worldObj instanceof WorldServer && ((WorldServer) this.worldObj).levelSaving) {
+            // World is saving/unloading: decorate everything still pending so no chunk is ever saved
+            // with terrain but without its decorations.
+            this.flushAllPendingForSave();
+        } else {
+            // Normal tick: decorate any pending chunk whose neighborhood has finished generating.
+            this.flushPending();
+        }
         return false;
+    }
+
+    private void flushAllPendingForSave() {
+        if (this.pendingDecoration.isEmpty()) {
+            return;
+        }
+        final IChunkProvider provider = this.worldObj.getChunkProvider();
+        if (!(provider instanceof ChunkProviderServer)) {
+            this.flushPending();
+            return;
+        }
+        final ChunkProviderServer serverProvider = (ChunkProviderServer) provider;
+        for (final ChunkCoordIntPair key : new ArrayList<>(this.pendingDecoration)) {
+            this.pendingDecoration.remove(key);
+            // Force-generate the decoration neighborhood as terrain-only chunks (no populate), then decorate.
+            // The terrain-only ring chunks are saved unpopulated and will be decorated normally on next load.
+            for (int dx = -DECOR_RADIUS; dx <= DECOR_RADIUS; ++dx) {
+                for (int dz = -DECOR_RADIUS; dz <= DECOR_RADIUS; ++dz) {
+                    final int nx = key.chunkXPos + dx;
+                    final int nz = key.chunkZPos + dz;
+                    if (!serverProvider.chunkExists(nx, nz)) {
+                        final Chunk chunk = this.provideChunk(nx, nz);
+                        serverProvider.loadedChunkHashMap.add(ChunkCoordIntPair.chunkXZ2Int(nx, nz), chunk);
+                        serverProvider.loadedChunks.add(chunk);
+                        chunk.onChunkLoad();
+                    }
+                }
+            }
+            this.doPopulate(key.chunkXPos, key.chunkZPos);
+        }
     }
 
     public boolean canSave() {

--- a/src/main/java/net/tropicraft/world/chunk/ChunkProviderTropicraft.java
+++ b/src/main/java/net/tropicraft/world/chunk/ChunkProviderTropicraft.java
@@ -509,12 +509,6 @@ public class ChunkProviderTropicraft implements IChunkProvider {
     }
 
     public boolean unloadQueuedChunks() {
-        if (!this.pendingDecoration.isEmpty() && this.worldObj.getTotalWorldTime() % 200L == 0L) {
-            System.out.println(
-                "[Tropicraft] deferred decoration pending: " + this.pendingDecoration.size()
-                    + " chunks, cascades detected: "
-                    + this.cascadesDetected);
-        }
         // Normal tick: decorate any pending chunk whose neighborhood has finished generating.
         this.flushPending();
         return false;

--- a/src/main/java/net/tropicraft/world/chunk/ChunkProviderTropicraft.java
+++ b/src/main/java/net/tropicraft/world/chunk/ChunkProviderTropicraft.java
@@ -16,7 +16,6 @@ import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.ChunkPosition;
 import net.minecraft.world.SpawnerAnimals;
 import net.minecraft.world.World;
-import net.minecraft.world.WorldServer;
 import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.IChunkProvider;
@@ -58,13 +57,17 @@ public class ChunkProviderTropicraft implements IChunkProvider {
      * This guarantees that every block read/write performed by decoration (trees, villages, etc.) lands in an
      * already-generated chunk, eliminating cascading chunk generation while keeping worldgen fully accurate.
      */
-    private static final int DECOR_RADIUS = 3;
+    private static final int DECOR_RADIUS = 4;
     /** Chunks whose terrain is generated but whose decorations are deferred until their neighborhood is loaded. */
     private final Set<ChunkCoordIntPair> pendingDecoration = new HashSet<>();
     /** Debug: depth of nesting while decorations are being applied (detects cascading chunk generation). */
     private int decoratingDepth;
+    /** Debug: the chunk currently being decorated (for cascade diagnostics). */
+    private ChunkCoordIntPair decoratingChunk;
     /** Debug: number of chunk generations triggered from inside decoration code (must be 0). */
     private long cascadesDetected;
+    /** All live providers, so pending decorations can be flushed when the server stops (before the final save). */
+    private static final Set<ChunkProviderTropicraft> activeProviders = new HashSet<>();
 
     public ChunkProviderTropicraft(final World worldObj, final long seed, final boolean par4) {
         this.worldObj = worldObj;
@@ -84,6 +87,18 @@ public class ChunkProviderTropicraft implements IChunkProvider {
         this.zirconGen = new WorldGenMinable(TCBlockRegistry.zirconOre, 4);
         this.azuriteGen = new WorldGenMinable(TCBlockRegistry.azuriteOre, 2);
         this.seed = seed;
+        ChunkProviderTropicraft.activeProviders.add(this);
+    }
+
+    /**
+     * Flushes all pending decorations on every live provider. Called from {@code FMLServerStoppingEvent},
+     * which fires before the final world save, so no chunk is ever saved with terrain but without its
+     * decorations.
+     */
+    public static void flushAllProvidersForSave() {
+        for (final ChunkProviderTropicraft provider : ChunkProviderTropicraft.activeProviders) {
+            provider.flushAllPendingForSave();
+        }
     }
 
     public Chunk provideChunk(final int x, final int z) {
@@ -98,7 +113,9 @@ public class ChunkProviderTropicraft implements IChunkProvider {
                         + " at chunk "
                         + x
                         + ","
-                        + z);
+                        + z
+                        + " while decorating "
+                        + this.decoratingChunk);
                 new Throwable("cascade trace").printStackTrace();
             }
         }
@@ -387,6 +404,7 @@ public class ChunkProviderTropicraft implements IChunkProvider {
 
     private void doPopulate(final int i, final int j) {
         ++this.decoratingDepth;
+        this.decoratingChunk = new ChunkCoordIntPair(i, j);
         try {
             BlockSand.fallInstantly = true;
             final int x = i * 16;
@@ -405,6 +423,7 @@ public class ChunkProviderTropicraft implements IChunkProvider {
                 .setChunkModified();
         } finally {
             --this.decoratingDepth;
+            this.decoratingChunk = null;
         }
     }
 
@@ -496,14 +515,8 @@ public class ChunkProviderTropicraft implements IChunkProvider {
                     + " chunks, cascades detected: "
                     + this.cascadesDetected);
         }
-        if (this.worldObj instanceof WorldServer && ((WorldServer) this.worldObj).levelSaving) {
-            // World is saving/unloading: decorate everything still pending so no chunk is ever saved
-            // with terrain but without its decorations.
-            this.flushAllPendingForSave();
-        } else {
-            // Normal tick: decorate any pending chunk whose neighborhood has finished generating.
-            this.flushPending();
-        }
+        // Normal tick: decorate any pending chunk whose neighborhood has finished generating.
+        this.flushPending();
         return false;
     }
 

--- a/src/main/java/net/tropicraft/world/chunk/ChunkProviderTropicraft.java
+++ b/src/main/java/net/tropicraft/world/chunk/ChunkProviderTropicraft.java
@@ -61,6 +61,10 @@ public class ChunkProviderTropicraft implements IChunkProvider {
     private static final int DECOR_RADIUS = 3;
     /** Chunks whose terrain is generated but whose decorations are deferred until their neighborhood is loaded. */
     private final Set<ChunkCoordIntPair> pendingDecoration = new HashSet<>();
+    /** Debug: depth of nesting while decorations are being applied (detects cascading chunk generation). */
+    private int decoratingDepth;
+    /** Debug: number of chunk generations triggered from inside decoration code (must be 0). */
+    private long cascadesDetected;
 
     public ChunkProviderTropicraft(final World worldObj, final long seed, final boolean par4) {
         this.worldObj = worldObj;
@@ -83,6 +87,21 @@ public class ChunkProviderTropicraft implements IChunkProvider {
     }
 
     public Chunk provideChunk(final int x, final int z) {
+        if (this.decoratingDepth > 0) {
+            // A chunk was generated from inside decoration code: that means some block read/write
+            // touched an unloaded chunk (cascading worldgen). With the deferred-decoration gate this
+            // should never happen; log it loudly so it can be fixed.
+            ++this.cascadesDetected;
+            if (this.cascadesDetected == 1L || this.cascadesDetected % 100L == 0L) {
+                System.err.println(
+                    "[Tropicraft] CASCADING CHUNK GENERATION DETECTED during decoration! count=" + this.cascadesDetected
+                        + " at chunk "
+                        + x
+                        + ","
+                        + z);
+                new Throwable("cascade trace").printStackTrace();
+            }
+        }
         this.rand.setSeed(x * 341873128712L + z * 132897987541L);
         final Block[] blocks = new Block[65536];
         final byte[] metas = new byte[65536];
@@ -367,21 +386,26 @@ public class ChunkProviderTropicraft implements IChunkProvider {
     }
 
     private void doPopulate(final int i, final int j) {
-        BlockSand.fallInstantly = true;
-        final int x = i * 16;
-        final int z = j * 16;
-        final BiomeGenTropicraft biome = (BiomeGenTropicraft) this.worldObj.getWorldChunkManager()
-            .getBiomeGenAt(x, z);
-        this.rand.setSeed(this.worldObj.getSeed());
-        final long l1 = this.rand.nextLong() / 2L * 2L + 1L;
-        final long l2 = this.rand.nextLong() / 2L * 2L + 1L;
-        this.rand.setSeed(i * l1 + j * l2 ^ this.worldObj.getSeed());
-        biome.decorate(this.worldObj, this.rand, x, z);
-        this.generateOres(x, z);
-        SpawnerAnimals.performWorldGenSpawning(this.worldObj, biome, x + 8, z + 8, 16, 16, this.rand);
-        BlockSand.fallInstantly = false;
-        this.worldObj.getChunkFromChunkCoords(i, j)
-            .setChunkModified();
+        ++this.decoratingDepth;
+        try {
+            BlockSand.fallInstantly = true;
+            final int x = i * 16;
+            final int z = j * 16;
+            final BiomeGenTropicraft biome = (BiomeGenTropicraft) this.worldObj.getWorldChunkManager()
+                .getBiomeGenAt(x, z);
+            this.rand.setSeed(this.worldObj.getSeed());
+            final long l1 = this.rand.nextLong() / 2L * 2L + 1L;
+            final long l2 = this.rand.nextLong() / 2L * 2L + 1L;
+            this.rand.setSeed(i * l1 + j * l2 ^ this.worldObj.getSeed());
+            biome.decorate(this.worldObj, this.rand, x, z);
+            this.generateOres(x, z);
+            SpawnerAnimals.performWorldGenSpawning(this.worldObj, biome, x + 8, z + 8, 16, 16, this.rand);
+            BlockSand.fallInstantly = false;
+            this.worldObj.getChunkFromChunkCoords(i, j)
+                .setChunkModified();
+        } finally {
+            --this.decoratingDepth;
+        }
     }
 
     private boolean isAreaLoaded(final int cx, final int cz, final int radius) {
@@ -466,6 +490,12 @@ public class ChunkProviderTropicraft implements IChunkProvider {
     }
 
     public boolean unloadQueuedChunks() {
+        if (!this.pendingDecoration.isEmpty() && this.worldObj.getTotalWorldTime() % 200L == 0L) {
+            System.out.println(
+                "[Tropicraft] deferred decoration pending: " + this.pendingDecoration.size()
+                    + " chunks, cascades detected: "
+                    + this.cascadesDetected);
+        }
         if (this.worldObj instanceof WorldServer && ((WorldServer) this.worldObj).levelSaving) {
             // World is saving/unloading: decorate everything still pending so no chunk is ever saved
             // with terrain but without its decorations.

--- a/src/main/java/net/tropicraft/world/location/TownKoaVillageGenHelper.java
+++ b/src/main/java/net/tropicraft/world/location/TownKoaVillageGenHelper.java
@@ -65,37 +65,35 @@ public class TownKoaVillageGenHelper {
         final int sizeHorizMax = TownKoaVillageGenHelper.areaWidth;
         final int sizeMiddle = TownKoaVillageGenHelper.areaWidth / 2;
         final int topYBeach = 62;
-        final Block blockScanBeach = parWorld.getBlock(parCoords.posX, topYBeach, parCoords.posZ);
-        if (blockScanBeach.getMaterial() == Material.sand) {
+        final Block blockScanBeach = getBlockIfLoaded(parWorld, parCoords.posX, topYBeach, parCoords.posZ);
+        if (blockScanBeach != null && blockScanBeach.getMaterial() == Material.sand) {
             final int topYMiddle = 62;
-            final Block blockScanMiddle = parWorld
-                .getBlock(parCoords.posX + sizeMiddle * scanX, topYMiddle, parCoords.posZ + sizeMiddle * scanZ);
-            System.out.println("testing scanX: " + scanX + " scanZ: " + scanZ);
-            if (blockScanMiddle.getMaterial() == Material.water) {
-                final Block blockScanEnd = parWorld
-                    .getBlock(parCoords.posX + sizeHorizMax * scanX, topYMiddle, parCoords.posZ + sizeHorizMax * scanZ);
-                System.out.println(
-                    "testing blockScanEnd x: " + (parCoords.posX + sizeHorizMax * scanX)
-                        + " z: "
-                        + (parCoords.posZ + sizeHorizMax * scanZ));
-                if (blockScanEnd.getMaterial() == Material.water) {
+            final Block blockScanMiddle = getBlockIfLoaded(
+                parWorld,
+                parCoords.posX + sizeMiddle * scanX,
+                topYMiddle,
+                parCoords.posZ + sizeMiddle * scanZ);
+            if (blockScanMiddle != null && blockScanMiddle.getMaterial() == Material.water) {
+                final Block blockScanEnd = getBlockIfLoaded(
+                    parWorld,
+                    parCoords.posX + sizeHorizMax * scanX,
+                    topYMiddle,
+                    parCoords.posZ + sizeHorizMax * scanZ);
+                if (blockScanEnd != null && blockScanEnd.getMaterial() == Material.water) {
                     for (int i = 1; i <= 4; ++i) {
                         final int sizeStep = sizeHorizMax / 4 * i;
-                        final Block blockScanFrontLeft = parWorld
-                            .getBlock(parCoords.posX + sizeStep * scanZ, topYMiddle, parCoords.posZ + sizeStep * scanX);
-                        final Block blockScanFrontRight = parWorld.getBlock(
+                        final Block blockScanFrontLeft = getBlockIfLoaded(
+                            parWorld,
+                            parCoords.posX + sizeStep * scanZ,
+                            topYMiddle,
+                            parCoords.posZ + sizeStep * scanX);
+                        final Block blockScanFrontRight = getBlockIfLoaded(
+                            parWorld,
                             parCoords.posX + sizeStep * scanZ * -1,
                             topYMiddle,
                             parCoords.posZ + sizeStep * scanX * -1);
-                        System.out.println(
-                            "testing blockScanFrontLeft x: " + (parCoords.posX + sizeStep * scanZ)
-                                + " z: "
-                                + (parCoords.posZ + sizeStep * scanX));
-                        System.out.println(
-                            "testing blockScanFrontRight x: " + (parCoords.posX + sizeStep * scanZ * -1)
-                                + " z: "
-                                + (parCoords.posZ + sizeStep * scanX * -1));
-                        if (blockScanFrontLeft.getMaterial() != Material.water
+                        if (blockScanFrontLeft == null || blockScanFrontRight == null
+                            || blockScanFrontLeft.getMaterial() != Material.water
                             || blockScanFrontRight.getMaterial() != Material.water) {
                             return false;
                         }
@@ -105,6 +103,20 @@ public class TownKoaVillageGenHelper {
             }
         }
         return false;
+    }
+
+    /**
+     * Reads a block only if its chunk is already loaded, returning null otherwise. Village scanning can
+     * probe up to {@link #areaWidth} blocks away from the chunk being populated; reading an unloaded chunk
+     * would synchronously generate it (cascading worldgen), so unloaded probes are treated as "not clear".
+     * This method consumes no random state, so other decoration in the chunk is unaffected.
+     */
+    private static Block getBlockIfLoaded(final World parWorld, final int x, final int y, final int z) {
+        if (!parWorld.getChunkProvider()
+            .chunkExists(x >> 4, z >> 4)) {
+            return null;
+        }
+        return parWorld.getBlock(x, y, z);
     }
 
     public static ChunkCoordinates getCoordsFromAdjustedDirection(final ChunkCoordinates parCoords,

--- a/src/main/java/net/tropicraft/world/worldgen/TCGenBase.java
+++ b/src/main/java/net/tropicraft/world/worldgen/TCGenBase.java
@@ -1,19 +1,12 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 
-import net.minecraft.block.Block;
-import net.minecraft.init.Blocks;
-import net.minecraft.util.ChunkCoordinates;
-import net.minecraft.util.MathHelper;
-import net.minecraft.world.World;
-import net.minecraft.world.chunk.Chunk;
-import net.minecraft.world.gen.feature.WorldGenerator;
+import net.minecraft.block.*;
+import net.minecraft.init.*;
+import net.minecraft.util.*;
+import net.minecraft.world.*;
+import net.minecraft.world.gen.feature.*;
 
 public abstract class TCGenBase extends WorldGenerator {
 
@@ -45,23 +38,13 @@ public abstract class TCGenBase extends WorldGenerator {
     public List<ChunkCoordinates> genCircle(final int x, final int y, final int z, final double outerRadius,
         final double innerRadius, final Block block, final int meta, final boolean solid) {
         List<ChunkCoordinates> generatedPositions = new ArrayList<>();
-        int chunkX = x >> 4;
-        int chunkZ = z >> 4;
-        Chunk chunk = worldObj.getChunkFromChunkCoords(x >> 4, z >> 4);
-        if (!chunk.isChunkLoaded) {
-            return null;
-        }
-        for (int chunkI = chunkX - (int) outerRadius - 1; chunkI <= chunkX + (int) outerRadius + 1; ++chunkI) {
-            for (int chunkK = chunkZ - (int) outerRadius - 1; chunkK <= chunkZ + (int) outerRadius + 1; ++chunkK) {
-                for (int i = chunkI << 4; i < (chunkI << 4) + 16; ++i) {
-                    for (int k = chunkK << 4; k < (chunkK << 4) + 16; ++k) {
-                        final double d = (double) ((i - x) * (i - x)) + (k - z) * (k - z);
-                        if (d <= outerRadius * outerRadius && d >= innerRadius * innerRadius
-                            && (this.worldObj.isAirBlock(i, y, k) || solid)
-                            && this.worldObj.setBlock(i, y, k, block, meta, TCGenBase.blockGenNotifyFlag)) {
-                            generatedPositions.add(new ChunkCoordinates(i, y, k));
-                        }
-                    }
+        for (int i = (int) (-outerRadius - 1.0) + x; i <= (int) (outerRadius + 1.0) + x; ++i) {
+            for (int k = (int) (-outerRadius - 1.0) + z; k <= (int) (outerRadius + 1.0) + z; ++k) {
+                final double d = (double) ((i - x) * (i - x)) + (k - z) * (k - z);
+                if (d <= outerRadius * outerRadius && d >= innerRadius * innerRadius
+                    && (this.worldObj.isAirBlock(i, y, k) || solid)
+                    && this.worldObj.setBlock(i, y, k, block, meta, TCGenBase.blockGenNotifyFlag)) {
+                    generatedPositions.add(new ChunkCoordinates(i, y, k));
                 }
             }
         }
@@ -75,6 +58,7 @@ public abstract class TCGenBase extends WorldGenerator {
                 final double d = (i - x) * (i - x) + (k - z) * (k - z);
                 if (d <= outerRadius * outerRadius && d >= innerRadius * innerRadius
                     && !allowedBlockList.contains(this.worldObj.getBlock(x, j, z))) {
+                    System.out.println("t2");
                     return false;
                 }
             }
@@ -82,7 +66,7 @@ public abstract class TCGenBase extends WorldGenerator {
         return true;
     }
 
-    public boolean checkBlockLine(final int[] ai, final int[] ai1, final List<Block> allowedBlockList) {
+    public boolean checkBlockLine(final int[] ai, final int[] ai1, final List allowedBlockList) {
         final int[] ai2 = { 0, 0, 0 };
         byte byte0 = 0;
         int j = 0;
@@ -107,88 +91,52 @@ public abstract class TCGenBase extends WorldGenerator {
         final double d = ai2[byte2] / (double) ai2[j];
         final double d2 = ai2[byte3] / (double) ai2[j];
         final int[] ai3 = { 0, 0, 0 };
-
-        World world = this.worldObj;
-
         for (int k = 0, l = ai2[j] + byte4; k != l; k += byte4) {
             ai3[j] = MathHelper.floor_double(ai[j] + k + 0.5);
             ai3[byte2] = MathHelper.floor_double(ai[byte2] + k * d + 0.5);
             ai3[byte3] = MathHelper.floor_double(ai[byte3] + k * d2 + 0.5);
-
-            int chunkX = ai3[0] >> 4;
-            int chunkZ = ai3[2] >> 4;
-
-            Chunk chunk = world.getChunkFromChunkCoords(chunkX, chunkZ);
-            if (!chunk.isChunkLoaded) {
-                return false;
-            }
-
-            Block block = chunk.getBlock(ai3[0] & 15, ai3[1], ai3[2] & 15);
-
-            if (!allowedBlockList.contains(block)) {
+            if (!allowedBlockList.contains(this.worldObj.getBlock(ai3[0], ai3[1], ai3[2]))) {
                 return false;
             }
         }
         return true;
     }
 
-    public void placeBlockLine(final int[] start, final int[] end, final Block block, final int meta) {
-        int[] difference = new int[] { end[0] - start[0], end[1] - start[1], end[2] - start[2] };
-        int largestDifferenceIndex = getLargestDifferenceIndex(difference);
-
-        if (difference[largestDifferenceIndex] == 0) {
-            return;
+    public List<int[]> placeBlockLine(final int[] ai, final int[] ai1, final Block block, final int meta) {
+        List<int[]> places = new ArrayList<>();
+        final int[] ai2 = { 0, 0, 0 };
+        byte byte0 = 0;
+        int j = 0;
+        while (byte0 < 3) {
+            ai2[byte0] = ai1[byte0] - ai[byte0];
+            if (Math.abs(ai2[byte0]) > Math.abs(ai2[j])) {
+                j = byte0;
+            }
+            ++byte0;
+        }
+        if (ai2[j] == 0) {
+            return places;
         }
 
-        byte[] otherCoordPairs = TCGenBase.otherCoordPairs;
-        byte otherCoord1 = otherCoordPairs[largestDifferenceIndex];
-        byte otherCoord2 = otherCoordPairs[largestDifferenceIndex + 3];
-        byte sign = (byte) (difference[largestDifferenceIndex] > 0 ? 1 : -1);
-        double d1 = difference[otherCoord1] / (double) difference[largestDifferenceIndex];
-        double d2 = difference[otherCoord2] / (double) difference[largestDifferenceIndex];
+        final byte byte2 = TCGenBase.otherCoordPairs[j];
+        final byte byte3 = TCGenBase.otherCoordPairs[j + 3];
+        final byte byte4 = (byte) (ai2[j] > 0 ? 1 : -1);
+        final double d = ai2[byte2] / (double) ai2[j];
+        final double d2 = ai2[byte3] / (double) ai2[j];
 
-        int chunkX = start[0] >> 4;
-        int chunkZ = start[2] >> 4;
+        int[] ai3 = { 0, 0, 0 };
+        for (int k = 0, l = ai2[j] + byte4; k != l; k += byte4) {
+            ai3[j] = MathHelper.floor_double(ai[j] + k + 0.5);
+            ai3[byte2] = MathHelper.floor_double(ai[byte2] + k * d + 0.5);
+            ai3[byte3] = MathHelper.floor_double(ai[byte3] + k * d2 + 0.5);
 
-        Set<String> placedBlocks = new HashSet<>();
-
-        int[] currentPos = new int[3];
-        for (int k = 0, l = difference[largestDifferenceIndex] + sign; k != l; k += sign) {
-            currentPos[largestDifferenceIndex] = MathHelper.floor_double(start[largestDifferenceIndex] + k + 0.5);
-            currentPos[otherCoord1] = MathHelper.floor_double(start[otherCoord1] + k * d1 + 0.5);
-            currentPos[otherCoord2] = MathHelper.floor_double(start[otherCoord2] + k * d2 + 0.5);
-
-            int blockChunkX = currentPos[0] >> 4;
-            int blockChunkZ = currentPos[2] >> 4;
-
-            if (blockChunkX != chunkX || blockChunkZ != chunkZ) {
-                chunkX = blockChunkX;
-                chunkZ = blockChunkZ;
-
-                Chunk chunk = worldObj.getChunkFromChunkCoords(chunkX, chunkZ);
-                if (!chunk.isChunkLoaded) {
-                    return;
-                }
-            }
-
-            String blockKey = currentPos[0] + "_" + currentPos[1] + "_" + currentPos[2];
-
-            if (worldObj.getBlock(currentPos[0], currentPos[1], currentPos[2]) != block) {
-                worldObj
-                    .setBlock(currentPos[0], currentPos[1], currentPos[2], block, meta, TCGenBase.blockGenNotifyFlag);
-                placedBlocks.add(blockKey);
+            // Check if the block is already placed
+            if (worldObj.getBlock(ai3[0], ai3[1], ai3[2]) != block) {
+                worldObj.setBlock(ai3[0], ai3[1], ai3[2], block, meta, TCGenBase.blockGenNotifyFlag);
+                places.add(new int[] { ai3[0], ai3[1], ai3[2] });
             }
         }
-    }
-
-    private int getLargestDifferenceIndex(int[] differences) {
-        int largestIndex = 0;
-        for (byte i = 0; i < 3; i++) {
-            if (Math.abs(differences[i]) > Math.abs(differences[largestIndex])) {
-                largestIndex = i;
-            }
-        }
-        return largestIndex;
+        return places;
     }
 
     public boolean checkBlockCircleLine(final int[] ai, final int[] ai1, final double outerRadius,
@@ -265,6 +213,7 @@ public abstract class TCGenBase extends WorldGenerator {
             }
         }
         for (int k = 0, l = ai2[j] + byte4; k != l; k += byte4) {
+            System.out.println("watwat");
             ai3[j] = MathHelper.floor_double(ai[j] + k + 0.5);
             ai3[byte2] = MathHelper.floor_double(ai[byte2] + k * d + 0.5);
             ai3[byte3] = MathHelper.floor_double(ai[byte3] + k * d2 + 0.5);

--- a/src/main/java/net/tropicraft/world/worldgen/TCGenBase.java
+++ b/src/main/java/net/tropicraft/world/worldgen/TCGenBase.java
@@ -1,12 +1,16 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
 
-import net.minecraft.block.*;
-import net.minecraft.init.*;
-import net.minecraft.util.*;
-import net.minecraft.world.*;
-import net.minecraft.world.gen.feature.*;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.ChunkCoordinates;
+import net.minecraft.util.MathHelper;
+import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenerator;
 
 public abstract class TCGenBase extends WorldGenerator {
 

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenBamboo.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenBamboo.java
@@ -1,11 +1,11 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.Random;
+import java.util.*;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.material.Material;
-import net.minecraft.world.World;
-import net.tropicraft.registry.TCBlockRegistry;
+import net.minecraft.block.*;
+import net.minecraft.block.material.*;
+import net.minecraft.world.*;
+import net.tropicraft.registry.*;
 
 public class WorldGenBamboo extends TCGenBase {
 
@@ -24,25 +24,18 @@ public class WorldGenBamboo extends TCGenBase {
         if (!this.worldObj.isAirBlock(i, j, k)) {
             return false;
         }
-
-        Material material1 = this.worldObj.getBlock(i + 1, j - 1, k)
-            .getMaterial();
-        Material material2 = this.worldObj.getBlock(i - 1, j - 1, k)
-            .getMaterial();
-        Material material3 = this.worldObj.getBlock(i, j - 1, k + 1)
-            .getMaterial();
-        Material material4 = this.worldObj.getBlock(i, j - 1, k - 1)
-            .getMaterial();
-
-        if (material1 != Material.water && material2 != Material.water
-            && material3 != Material.water
-            && material4 != Material.water) {
+        if (this.worldObj.getBlock(i + 1, j - 1, k)
+            .getMaterial() != Material.water
+            && this.worldObj.getBlock(i - 1, j - 1, k)
+                .getMaterial() != Material.water
+            && this.worldObj.getBlock(i, j - 1, k + 1)
+                .getMaterial() != Material.water
+            && this.worldObj.getBlock(i, j - 1, k - 1)
+                .getMaterial() != Material.water) {
             return false;
         }
-
         final int amount = this.rand.nextInt(30) + 30;
         final int spread = this.rand.nextInt(3) - 1 + (int) (Math.sqrt(amount) / 2.0);
-
         for (int l = 0; l < amount; ++l) {
             for (int x = i + this.rand.nextInt(spread) - this.rand.nextInt(spread),
                 z = k + this.rand.nextInt(spread) - this.rand.nextInt(spread), y = this.getTerrainHeightAt(x, z),

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenBamboo.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenBamboo.java
@@ -1,11 +1,11 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.*;
+import java.util.Random;
 
-import net.minecraft.block.*;
-import net.minecraft.block.material.*;
-import net.minecraft.world.*;
-import net.tropicraft.registry.*;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.world.World;
+import net.tropicraft.registry.TCBlockRegistry;
 
 public class WorldGenBamboo extends TCGenBase {
 

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenCoffeePlant.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenCoffeePlant.java
@@ -5,19 +5,20 @@ import java.util.Random;
 import net.minecraft.block.material.Material;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
-import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.tropicraft.registry.TCBlockRegistry;
 
 public class WorldGenCoffeePlant extends TCGenBase {
+
+    private static final ForgeDirection[] cardinalDirections;
 
     public WorldGenCoffeePlant(final World world, final Random rand) {
         super(world, rand);
     }
 
     public boolean generate(final int x, final int y, final int z) {
-        final int nx = generateRandomOffset(x);
-        final int nz = generateRandomOffset(z);
+        final int nx = x + this.rand.nextInt(8) - this.rand.nextInt(8);
+        final int nz = z + this.rand.nextInt(8) - this.rand.nextInt(8);
 
         if (!isValidLocation(nx, y, nz)) {
             return false;
@@ -34,17 +35,12 @@ public class WorldGenCoffeePlant extends TCGenBase {
         return true;
     }
 
-    private int generateRandomOffset(int value) {
-        int offset = this.rand.nextInt(8) - this.rand.nextInt(8);
-        return Math.min(Math.max(value + offset, 0), 15);
-    }
-
     private boolean isValidLocation(int x, int y, int z) {
         return this.worldObj.isAirBlock(x, y, z) && this.worldObj.getBlock(x, y - 1, z) == Blocks.grass;
     }
 
     private ForgeDirection findViableDirection(int x, int y, int z) {
-        for (final ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
+        for (final ForgeDirection dir : WorldGenCoffeePlant.cardinalDirections) {
             final int neighborx = x + dir.offsetX;
             final int neighborz = z + dir.offsetZ;
             if (this.worldObj.getBlock(neighborx, y - 1, neighborz)
@@ -56,7 +52,7 @@ public class WorldGenCoffeePlant extends TCGenBase {
     }
 
     private ForgeDirection checkSurrounded(int x, int y, int z) {
-        for (final ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
+        for (final ForgeDirection dir : WorldGenCoffeePlant.cardinalDirections) {
             final int neighborx = x + dir.offsetX;
             final int neighborz = z + dir.offsetZ;
             if (this.worldObj.isAirBlock(neighborx, y, neighborz)
@@ -70,7 +66,7 @@ public class WorldGenCoffeePlant extends TCGenBase {
     }
 
     private boolean isSurrounded(int x, int y, int z) {
-        for (final ForgeDirection surroundingDir : ForgeDirection.VALID_DIRECTIONS) {
+        for (final ForgeDirection surroundingDir : WorldGenCoffeePlant.cardinalDirections) {
             final int surroundingx = x + surroundingDir.offsetX;
             final int surroundingz = z + surroundingDir.offsetZ;
             if (!this.worldObj.isAirBlock(surroundingx, y, surroundingz)
@@ -82,11 +78,6 @@ public class WorldGenCoffeePlant extends TCGenBase {
     }
 
     private void placeBlocks(int x, int y, int z, ForgeDirection direction) {
-        Chunk chunk = worldObj.getChunkFromChunkCoords(x >> 4, z >> 4);
-        if (!chunk.isChunkLoaded) {
-            return;
-        }
-
         this.worldObj.setBlock(
             x + direction.offsetX,
             y - 1,
@@ -95,9 +86,13 @@ public class WorldGenCoffeePlant extends TCGenBase {
             0,
             WorldGenCoffeePlant.blockGenNotifyFlag);
         this.worldObj.setBlock(x, y - 1, z, Blocks.farmland, 7, WorldGenCoffeePlant.blockGenNotifyFlag);
-
         for (int i = 0; i < 3 && this.worldObj.isAirBlock(x, y + i, z); ++i) {
             this.worldObj.setBlock(x, y + i, z, TCBlockRegistry.coffeePlant, 6, WorldGenCoffeePlant.blockGenNotifyFlag);
         }
+    }
+
+    static {
+        cardinalDirections = new ForgeDirection[] { ForgeDirection.NORTH, ForgeDirection.EAST, ForgeDirection.SOUTH,
+            ForgeDirection.WEST };
     }
 }

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenHomeTree.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenHomeTree.java
@@ -41,7 +41,6 @@ public class WorldGenHomeTree extends TCGenBase {
         if (height + j + 12 > 255) {
             return false;
         }
-        System.err.println("HOME TREE INCOMING! " + i + " " + j + " " + k);
         final int[] top = this.generateTrunk(i, j, k, height);
         this.generateBranches(top[0], top[1], height + j);
         return true;

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenHomeTree.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenHomeTree.java
@@ -1,14 +1,20 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
-import net.minecraft.block.*;
-import net.minecraft.init.*;
-import net.minecraft.item.*;
-import net.minecraft.tileentity.*;
-import net.minecraft.util.*;
-import net.minecraft.world.*;
-import net.tropicraft.registry.*;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntityChest;
+import net.minecraft.tileentity.TileEntityMobSpawner;
+import net.minecraft.util.ChunkCoordinates;
+import net.minecraft.util.MathHelper;
+import net.minecraft.world.World;
+import net.tropicraft.registry.TCBlockRegistry;
+import net.tropicraft.registry.TCItemRegistry;
 
 public class WorldGenHomeTree extends TCGenBase {
 

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenHomeTree.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenHomeTree.java
@@ -1,20 +1,14 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 
-import net.minecraft.block.Block;
-import net.minecraft.init.Blocks;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntityChest;
-import net.minecraft.tileentity.TileEntityMobSpawner;
-import net.minecraft.util.ChunkCoordinates;
-import net.minecraft.util.MathHelper;
-import net.minecraft.world.World;
-import net.tropicraft.registry.TCBlockRegistry;
-import net.tropicraft.registry.TCItemRegistry;
+import net.minecraft.block.*;
+import net.minecraft.init.*;
+import net.minecraft.item.*;
+import net.minecraft.tileentity.*;
+import net.minecraft.util.*;
+import net.minecraft.world.*;
+import net.tropicraft.registry.*;
 
 public class WorldGenHomeTree extends TCGenBase {
 
@@ -27,9 +21,9 @@ public class WorldGenHomeTree extends TCGenBase {
 
     public WorldGenHomeTree(final World world, final Random random) {
         super(world, random);
-        this.woodID = TCBlockRegistry.logs;
-        this.leafID = TCBlockRegistry.rainforestLeaves;
-        this.branchList = new ArrayList<>();
+        this.woodID = (Block) TCBlockRegistry.logs;
+        this.leafID = (Block) TCBlockRegistry.rainforestLeaves;
+        this.branchList = new ArrayList<BranchNode>();
     }
 
     public boolean generate(final int i, int j, final int k) {
@@ -47,6 +41,7 @@ public class WorldGenHomeTree extends TCGenBase {
         if (height + j + 12 > 255) {
             return false;
         }
+        System.err.println("HOME TREE INCOMING! " + i + " " + j + " " + k);
         final int[] top = this.generateTrunk(i, j, k, height);
         this.generateBranches(top[0], top[1], height + j);
         return true;
@@ -132,28 +127,63 @@ public class WorldGenHomeTree extends TCGenBase {
     }
 
     public void generateBranches(final int topX, final int topZ, final int height) {
-        final int lSize = 3;
-        int[][] coords = new int[6][3];
-
-        for (final BranchNode bnode : this.branchList) {
-            coords[0] = new int[] { bnode.x1, bnode.y1, bnode.z1 };
-            coords[1] = new int[] { bnode.x2, bnode.y2, bnode.z2 };
-            coords[2] = new int[] { bnode.x1 + 1, bnode.y1, bnode.z1 };
-            coords[3] = new int[] { bnode.x2 + 1, bnode.y2, bnode.z2 };
-            coords[4] = new int[] { bnode.x1 - 1, bnode.y1, bnode.z1 };
-            coords[5] = new int[] { bnode.x2 - 1, bnode.y2, bnode.z2 };
-
-            boolean shouldPlaceBlock = false;
-            for (int i = 0; i < 6; i += 2) {
-                shouldPlaceBlock = shouldPlaceBlock
-                    || this.checkBlockLine(coords[i], coords[i + 1], this.standardAllowedBlocks);
-            }
-
-            if (shouldPlaceBlock) {
-                for (int i = 0; i < 6; i += 2) {
-                    this.placeBlockLine(coords[i], coords[i + 1], this.woodID, 1);
-                }
-
+        for (int x = 0; x < this.branchList.size(); ++x) {
+            final BranchNode bnode = this.branchList.get(x);
+            final int lSize = 3;
+            if (this.checkBlockLine(
+                new int[] { bnode.x1, bnode.y1, bnode.z1 },
+                new int[] { bnode.x2, bnode.y2, bnode.z2 },
+                this.standardAllowedBlocks)
+                || this.checkBlockLine(
+                    new int[] { bnode.x1 + 1, bnode.y1, bnode.z1 },
+                    new int[] { bnode.x2 + 1, bnode.y2, bnode.z2 },
+                    this.standardAllowedBlocks)
+                || this.checkBlockLine(
+                    new int[] { bnode.x1 - 1, bnode.y1, bnode.z1 },
+                    new int[] { bnode.x2 - 1, bnode.y2, bnode.z2 },
+                    this.standardAllowedBlocks)
+                || this.checkBlockLine(
+                    new int[] { bnode.x1, bnode.y1, bnode.z1 + 1 },
+                    new int[] { bnode.x2, bnode.y2, bnode.z2 + 1 },
+                    this.standardAllowedBlocks)
+                || this.checkBlockLine(
+                    new int[] { bnode.x1, bnode.y1, bnode.z1 - 1 },
+                    new int[] { bnode.x2, bnode.y2, bnode.z2 - 1 },
+                    this.standardAllowedBlocks)
+                || this.checkBlockLine(
+                    new int[] { bnode.x1, bnode.y1 - 1, bnode.z1 },
+                    new int[] { bnode.x2, bnode.y2 - 1, bnode.z2 },
+                    this.standardAllowedBlocks)) {
+                this.placeBlockLine(
+                    new int[] { bnode.x1, bnode.y1, bnode.z1 },
+                    new int[] { bnode.x2, bnode.y2, bnode.z2 },
+                    this.woodID,
+                    1);
+                this.placeBlockLine(
+                    new int[] { bnode.x1 + 1, bnode.y1, bnode.z1 },
+                    new int[] { bnode.x2 + 1, bnode.y2, bnode.z2 },
+                    this.woodID,
+                    1);
+                this.placeBlockLine(
+                    new int[] { bnode.x1 - 1, bnode.y1, bnode.z1 },
+                    new int[] { bnode.x2 - 1, bnode.y2, bnode.z2 },
+                    this.woodID,
+                    1);
+                this.placeBlockLine(
+                    new int[] { bnode.x1, bnode.y1, bnode.z1 + 1 },
+                    new int[] { bnode.x2, bnode.y2, bnode.z2 + 1 },
+                    this.woodID,
+                    1);
+                this.placeBlockLine(
+                    new int[] { bnode.x1, bnode.y1, bnode.z1 - 1 },
+                    new int[] { bnode.x2, bnode.y2, bnode.z2 - 1 },
+                    this.woodID,
+                    1);
+                this.placeBlockLine(
+                    new int[] { bnode.x1, bnode.y1 - 1, bnode.z1 },
+                    new int[] { bnode.x2, bnode.y2 - 1, bnode.z2 },
+                    this.woodID,
+                    1);
                 if (bnode.y2 + 1 <= height) {
                     this.placeBlockLine(
                         new int[] { bnode.x1, bnode.y1 + 1, bnode.z1 },
@@ -161,14 +191,12 @@ public class WorldGenHomeTree extends TCGenBase {
                         this.woodID,
                         1);
                 }
-
                 this.genLeafCircle(bnode.x2, bnode.y2 - 1, bnode.z2, lSize + 5, lSize + 3, this.leafID, 0, true);
                 this.genLeafCircle(bnode.x2, bnode.y2, bnode.z2, lSize + 6, 0, this.leafID, 0, true);
                 this.genLeafCircle(bnode.x2, bnode.y2 + 1, bnode.z2, lSize + 10, 0, this.leafID, 0, true);
                 this.genLeafCircle(bnode.x2, bnode.y2 + 2, bnode.z2, lSize + 9, 0, this.leafID, 0, true);
             }
         }
-
         final int topBranches = this.rand.nextInt(6) + 6;
     }
 
@@ -211,7 +239,6 @@ public class WorldGenHomeTree extends TCGenBase {
         final Block leafID2, final int meta, final boolean vines) {
         final int outerRadiusSquared = outerRadius * outerRadius;
         final int innerRadiusSquared = innerRadius * innerRadius;
-
         for (int i = -outerRadius + x; i < outerRadius + x; ++i) {
             for (int k = -outerRadius + z; k < outerRadius + z; ++k) {
                 final double d = (x - i) * (x - i) + (z - k) * (z - k);
@@ -238,17 +265,16 @@ public class WorldGenHomeTree extends TCGenBase {
     public boolean placeBlock(final int i, final int j, final int k, final Block woodID2, final int meta,
         final boolean force) {
         final Block bID = this.worldObj.getBlock(i, j, k);
-        if (!force && !canReplaceBlock(bID)) {
+        if (!force && bID != Blocks.water
+            && bID != Blocks.flowing_water
+            && bID != TCBlockRegistry.tropicsWater
+            && bID != Blocks.air) {
             return false;
         }
-
-        return this.worldObj.setBlock(i, j, k, woodID2, meta, TCGenBase.blockGenNotifyFlag);
-    }
-
-    private boolean canReplaceBlock(Block block) {
-        return block == Blocks.water || block == Blocks.flowing_water
-            || block == TCBlockRegistry.tropicsWater
-            || block == Blocks.air;
+        if (meta == 0) {
+            return this.worldObj.setBlock(i, j, k, woodID2, 0, 0);
+        }
+        return this.worldObj.setBlock(i, j, k, woodID2, meta, 0);
     }
 
     public List<ChunkCoordinates> genCircle(final int i, final int j, final int k, final double outerRadius,
@@ -273,7 +299,7 @@ public class WorldGenHomeTree extends TCGenBase {
         return generatedCoordinates;
     }
 
-    public void placeBlockLine(final int[] ai, final int[] ai1, final Block i, final int meta) {
+    public ArrayList<int[]> placeBlockLine(final int[] ai, final int[] ai1, final Block i, final int meta) {
         final ArrayList<int[]> places = new ArrayList<int[]>();
         final int[] ai2 = { 0, 0, 0 };
         byte byte0 = 0;
@@ -286,7 +312,7 @@ public class WorldGenHomeTree extends TCGenBase {
             ++byte0;
         }
         if (ai2[j] == 0) {
-            return;
+            return null;
         }
         final byte byte2 = WorldGenHomeTree.otherCoordPairs[j];
         final byte byte3 = WorldGenHomeTree.otherCoordPairs[j + 3];
@@ -306,6 +332,7 @@ public class WorldGenHomeTree extends TCGenBase {
             this.placeBlock(ai3[0], ai3[1], ai3[2], i, meta, true);
             places.add(new int[] { ai3[0], ai3[1], ai3[2] });
         }
+        return places;
     }
 
     public ArrayList<int[]> checkAndPlaceBlockLine(final int[] ai, final int[] ai1, final Block i, final int meta,

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenHomeTree.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenHomeTree.java
@@ -272,9 +272,9 @@ public class WorldGenHomeTree extends TCGenBase {
             return false;
         }
         if (meta == 0) {
-            return this.worldObj.setBlock(i, j, k, woodID2, 0, 0);
+            return this.worldObj.setBlock(i, j, k, woodID2, 0, TCGenBase.blockGenNotifyFlag);
         }
-        return this.worldObj.setBlock(i, j, k, woodID2, meta, 0);
+        return this.worldObj.setBlock(i, j, k, woodID2, meta, TCGenBase.blockGenNotifyFlag);
     }
 
     public List<ChunkCoordinates> genCircle(final int i, final int j, final int k, final double outerRadius,

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenTCUndergrowth.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenTCUndergrowth.java
@@ -1,11 +1,11 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.*;
+import java.util.Random;
 
-import net.minecraft.block.*;
-import net.minecraft.init.*;
-import net.minecraft.world.*;
-import net.tropicraft.registry.*;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.world.World;
+import net.tropicraft.registry.TCBlockRegistry;
 
 public class WorldGenTCUndergrowth extends TCGenBase {
 

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenTCUndergrowth.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenTCUndergrowth.java
@@ -1,12 +1,11 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.Random;
+import java.util.*;
 
-import net.minecraft.block.Block;
-import net.minecraft.init.Blocks;
-import net.minecraft.world.World;
-import net.minecraft.world.chunk.Chunk;
-import net.tropicraft.registry.TCBlockRegistry;
+import net.minecraft.block.*;
+import net.minecraft.init.*;
+import net.minecraft.world.*;
+import net.tropicraft.registry.*;
 
 public class WorldGenTCUndergrowth extends TCGenBase {
 
@@ -21,42 +20,24 @@ public class WorldGenTCUndergrowth extends TCGenBase {
     }
 
     public boolean generate(final int i, final int j, final int k) {
-        int chunkX = i >> 4;
-        int chunkZ = k >> 4;
-
-        Chunk chunk = worldObj.getChunkFromChunkCoords(chunkX >> 4, chunkZ >> 4);
-        if (!chunk.isChunkLoaded) {
+        final Block blockUnder = this.worldObj.getBlock(i, j - 1, k);
+        if (blockUnder != Blocks.dirt && blockUnder != Blocks.grass) {
             return false;
         }
-
-        if (!isValidUnderBlock(i, j, k)) {
-            return false;
+        this.worldObj.setBlock(i, j, k, WorldGenTCUndergrowth.WOOD_BLOCK, 1, WorldGenTCUndergrowth.blockGenNotifyFlag);
+        int size = 2;
+        if (this.rand.nextInt(10) == 0) {
+            size = 3;
         }
-
-        placeWoodBlock(i, j, k);
-
-        int size = (this.rand.nextInt(10) == 0) ? 3 : 2;
-
-        int chunkStartX = (i - size) >> 4;
-        int chunkStartZ = (k - size) >> 4;
-        int chunkEndX = (i + size) >> 4;
-        int chunkEndZ = (k + size) >> 4;
         for (int y = j; y < j + size; ++y) {
-            for (int x = i - size; x <= i + size; ++x) {
+            for (int bushWidth = size - (y - j), x = i - bushWidth; x < i + bushWidth; ++x) {
                 final int xVariance = x - i;
-                for (int z = k - size; z <= k + size; ++z) {
+                for (int z = k - bushWidth; z < k + bushWidth; ++z) {
                     final int zVariance = z - k;
-                    int blockChunkX = x >> 4;
-                    int blockChunkZ = z >> 4;
-                    if (shouldPlaceLeafBlock(
-                        xVariance,
-                        zVariance,
-                        blockChunkX,
-                        blockChunkZ,
-                        chunkStartX,
-                        chunkStartZ,
-                        chunkEndX,
-                        chunkEndZ)) {
+                    if ((Math.abs(xVariance) != bushWidth || Math.abs(zVariance) != bushWidth
+                        || this.rand.nextInt(2) != 0)
+                        && !this.worldObj.getBlock(x, y, z)
+                            .isOpaqueCube()) {
                         this.worldObj.setBlock(
                             x,
                             y,
@@ -68,29 +49,11 @@ public class WorldGenTCUndergrowth extends TCGenBase {
                 }
             }
         }
-
         return true;
     }
 
-    private boolean isValidUnderBlock(int i, int j, int k) {
-        final Block blockUnder = this.worldObj.getBlock(i, j - 1, k);
-        return blockUnder == Blocks.dirt || blockUnder == Blocks.grass;
-    }
-
-    private void placeWoodBlock(int i, int j, int k) {
-        this.worldObj.setBlock(i, j, k, WorldGenTCUndergrowth.WOOD_BLOCK, 1, WorldGenTCUndergrowth.blockGenNotifyFlag);
-    }
-
-    private boolean shouldPlaceLeafBlock(int xVariance, int zVariance, int blockChunkX, int blockChunkZ,
-        int chunkStartX, int chunkStartZ, int chunkEndX, int chunkEndZ) {
-        return (Math.abs(xVariance) != 2 || Math.abs(zVariance) != 2 || this.rand.nextInt(2) != 0)
-            && (blockChunkX >= chunkStartX && blockChunkX <= chunkEndX
-                && blockChunkZ >= chunkStartZ
-                && blockChunkZ <= chunkEndZ);
-    }
-
     static {
-        WOOD_BLOCK = TCBlockRegistry.logs;
-        LEAF_BLOCK = TCBlockRegistry.rainforestLeaves;
+        WOOD_BLOCK = (Block) TCBlockRegistry.logs;
+        LEAF_BLOCK = (Block) TCBlockRegistry.rainforestLeaves;
     }
 }

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenTallFlower.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenTallFlower.java
@@ -1,11 +1,9 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.Random;
+import java.util.*;
 
-import net.minecraft.block.Block;
-import net.minecraft.init.Blocks;
-import net.minecraft.world.World;
-import net.minecraft.world.chunk.Chunk;
+import net.minecraft.block.*;
+import net.minecraft.world.*;
 
 public class WorldGenTallFlower extends TCGenBase {
 
@@ -17,53 +15,30 @@ public class WorldGenTallFlower extends TCGenBase {
     public WorldGenTallFlower(final World world, final Random rand, final Block plantBlock, final int plantBottomMeta,
         final int plantTopMeta) {
         super(world, rand);
-        this.FLOWER_TRIES = 4;
+        this.FLOWER_TRIES = 12;
         this.plantBlock = plantBlock;
         this.plantBottomMeta = plantBottomMeta;
         this.plantTopMeta = plantTopMeta;
     }
 
     public boolean generate(final int i, final int j, final int k) {
-        int chunkX = i >> 4;
-        int chunkZ = k >> 4;
-
-        Chunk chunk = worldObj.getChunkFromChunkCoords(chunkX >> 4, chunkZ >> 4);
-        if (!chunk.isChunkLoaded) {
-            return false;
-        }
-
-        int radius = 5;
-
         for (int l = 0; l < this.FLOWER_TRIES; ++l) {
-            final int i2 = i + this.rand.nextInt(radius * 2 + 1) - radius;
-            final int j2 = j + this.rand.nextInt(7) - 3;
-            final int k2 = k + this.rand.nextInt(radius * 2 + 1) - radius;
-
-            if (isWithinChunkBounds(i2, k2, chunkX, chunkZ)) {
-                Block block = this.worldObj.getBlock(i2, j2, k2);
-                Block blockAbove = this.worldObj.getBlock(i2, j2 + 1, k2);
-
-                if (block == Blocks.grass && (blockAbove == Blocks.air || blockAbove == Blocks.tallgrass)
-                    && this.plantBlock.canBlockStay(this.worldObj, i2, j2, k2)) {
-                    placeFlower(i2, j2, k2);
-                }
+            final int i2 = i + this.rand.nextInt(8) - this.rand.nextInt(8);
+            final int j2 = j + this.rand.nextInt(3) - this.rand.nextInt(3);
+            final int k2 = k + this.rand.nextInt(8) - this.rand.nextInt(8);
+            if (this.worldObj.isAirBlock(i2, j2, k2) && this.worldObj.isAirBlock(i2, j2 + 1, k2)
+                && this.plantBlock.canBlockStay(this.worldObj, i2, j2, k2)) {
+                this.worldObj
+                    .setBlock(i2, j2, k2, this.plantBlock, this.plantBottomMeta, WorldGenTallFlower.blockGenNotifyFlag);
+                this.worldObj.setBlock(
+                    i2,
+                    j2 + 1,
+                    k2,
+                    this.plantBlock,
+                    this.plantTopMeta,
+                    WorldGenTallFlower.blockGenNotifyFlag);
             }
         }
-
         return true;
-    }
-
-    private boolean isWithinChunkBounds(int i, int k, int chunkX, int chunkZ) {
-        int chunkStartX = chunkX << 4;
-        int chunkStartZ = chunkZ << 4;
-        int chunkEndX = chunkStartX + 15;
-        int chunkEndZ = chunkStartZ + 15;
-
-        return i >= chunkStartX && i <= chunkEndX && k >= chunkStartZ && k <= chunkEndZ;
-    }
-
-    private void placeFlower(int i, int j, int k) {
-        this.worldObj.setBlock(i, j, k, this.plantBlock, this.plantBottomMeta, 2);
-        this.worldObj.setBlock(i, j + 1, k, this.plantBlock, this.plantTopMeta, 2);
     }
 }

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenTallFlower.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenTallFlower.java
@@ -1,9 +1,9 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.*;
+import java.util.Random;
 
-import net.minecraft.block.*;
-import net.minecraft.world.*;
+import net.minecraft.block.Block;
+import net.minecraft.world.World;
 
 public class WorldGenTallFlower extends TCGenBase {
 

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenTallTree.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenTallTree.java
@@ -1,12 +1,13 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.*;
+import java.util.Random;
 
-import net.minecraft.block.*;
-import net.minecraft.init.*;
-import net.minecraft.util.*;
-import net.minecraft.world.*;
-import net.tropicraft.registry.*;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.Direction;
+import net.minecraft.util.Facing;
+import net.minecraft.world.World;
+import net.tropicraft.registry.TCBlockRegistry;
 
 public class WorldGenTallTree extends TCGenBase {
 

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenTallTree.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenTallTree.java
@@ -1,17 +1,12 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 
-import net.minecraft.block.Block;
-import net.minecraft.init.Blocks;
-import net.minecraft.util.ChunkCoordinates;
-import net.minecraft.util.Direction;
-import net.minecraft.util.Facing;
-import net.minecraft.world.World;
-import net.minecraft.world.chunk.Chunk;
-import net.tropicraft.registry.TCBlockRegistry;
+import net.minecraft.block.*;
+import net.minecraft.init.*;
+import net.minecraft.util.*;
+import net.minecraft.world.*;
+import net.tropicraft.registry.*;
 
 public class WorldGenTallTree extends TCGenBase {
 
@@ -32,10 +27,6 @@ public class WorldGenTallTree extends TCGenBase {
     }
 
     public boolean generate(final int i, final int j, final int k) {
-        Chunk chunk = worldObj.getChunkFromChunkCoords(i >> 4, k >> 4);
-        if (!chunk.isChunkLoaded) {
-            return false;
-        }
         Block blockUnder = this.worldObj.getBlock(i, j - 1, k);
         if (blockUnder != Blocks.dirt && blockUnder != Blocks.grass) {
             return false;
@@ -87,7 +78,7 @@ public class WorldGenTallTree extends TCGenBase {
                     for (int z2 = nz - 3; z2 <= nz + 3; ++z2) {
                         for (int y2 = y - 1; y2 <= y; ++y2) {
                             if (this.rand.nextInt(5) == 0) {
-                                this.generateVinesAt(x2, y2, z2);
+                                this.genVines(x2, y2, z2);
                             }
                         }
                     }
@@ -109,7 +100,7 @@ public class WorldGenTallTree extends TCGenBase {
                     for (int z3 = nz - leafSize; z3 <= nz + leafSize; ++z3) {
                         for (int y3 = y; y3 <= y + 2; ++y3) {
                             if (this.rand.nextInt(5) == 0) {
-                                this.generateVinesAt(x3, y3, z3);
+                                this.genVines(x3, y3, z3);
                             }
                         }
                     }
@@ -120,127 +111,45 @@ public class WorldGenTallTree extends TCGenBase {
         this.genCircle(i, j + height, k, leafSize2 - 2, 0.0, WorldGenTallTree.LEAF_BLOCK, 1, false);
         this.genCircle(i, j + height - 1, k, (leafSize2 - 1), (leafSize2 - 4), WorldGenTallTree.LEAF_BLOCK, 1, false);
         this.genCircle(i, j + height - 2, k, leafSize2, (leafSize2 - 1), WorldGenTallTree.LEAF_BLOCK, 1, false);
-
-        generateVineCluster(i, j, k, leafSize2, height);
-        return true;
-    }
-
-    private void generateVineCluster(int i, int j, int k, int leafSize2, int height) {
-        List<ChunkCoordinates> vineCoordinates = new ArrayList<>();
-
         for (int x = i - leafSize2; x <= i + leafSize2; ++x) {
             for (int z = k - leafSize2; z <= k + leafSize2; ++z) {
                 for (int y4 = j + height + 3; y4 <= j + height + 6; ++y4) {
                     if (this.rand.nextInt(5) == 0) {
-                        vineCoordinates.add(new ChunkCoordinates(x, y4, z));
+                        this.genVines(x, y4, z);
                     }
                 }
             }
         }
-
-        placeVines(vineCoordinates);
+        return true;
     }
 
-    private void placeVines(List<ChunkCoordinates> vineCoordinates) {
-        int vineChance = 5;
-
-        for (ChunkCoordinates pos : vineCoordinates) {
-            int posX = pos.posX;
-            int posY = pos.posY;
-            int posZ = pos.posZ;
-
-            if (this.rand.nextInt(vineChance) == 0 && canPlaceVines(posX, posY, posZ)) {
-                generateVinesAt(posX, posY, posZ);
-            }
-        }
-    }
-
-    private boolean canPlaceVines(int x, int y, int z) {
-        Block vineBlock = Blocks.vine;
-
-        World world = this.worldObj;
-
-        int chunkX = x >> 4;
-        int chunkZ = z >> 4;
-
-        Chunk chunk = world.getChunkFromChunkCoords(x >> 4, z >> 4);
-        if (!chunk.isChunkLoaded) {
-            return false;
-        }
-
-        Block blockAtPos = world.getBlock(x, y, z);
-        Block blockAbove = world.getBlock(x, y + 1, z);
-        Block blockBelow = world.getBlock(x, y - 1, z);
-
-        boolean isAir = blockAtPos.isAir(world, x, y, z);
-        boolean isAirAbove = blockAbove.isAir(world, x, y + 1, z);
-        boolean isAirBelow = blockBelow.isAir(world, x, y - 1, z);
-
-        return isAir && isAirAbove && isAirBelow && blockAtPos == vineBlock && !vineExistsNearby(x, y, z);
-    }
-
-    private boolean vineExistsNearby(int x, int y, int z) {
-        int range = 2;
-        for (int i = x - range; i <= x + range; i++) {
-            for (int j = y - range; j <= y + range; j++) {
-                for (int k = z - range; k <= z + range; k++) {
-                    if (this.worldObj.getBlock(i, j, k) == Blocks.vine) {
+    private boolean genVines(final int i, final int j, final int k) {
+        for (int m = 2; m <= 5; ++m) {
+            if (Blocks.vine.canPlaceBlockOnSide(this.worldObj, i, j, k, m)
+                && this.worldObj.getBlock(i, j, k) == Blocks.air) {
+                this.worldObj.setBlock(
+                    i,
+                    j,
+                    k,
+                    Blocks.vine,
+                    1 << Direction.facingToDirection[Facing.oppositeSide[m]],
+                    WorldGenTallTree.blockGenNotifyFlag);
+                for (int length = this.rand.nextInt(4) + 4, y = j - 1; y > j - length; --y) {
+                    if (this.worldObj.getBlock(i, y, k) != Blocks.air) {
                         return true;
                     }
+                    this.worldObj.setBlock(
+                        i,
+                        y,
+                        k,
+                        Blocks.vine,
+                        1 << Direction.facingToDirection[Facing.oppositeSide[m]],
+                        WorldGenTallTree.blockGenNotifyFlag);
                 }
+                return true;
             }
         }
         return false;
-    }
-
-    private void generateVinesAt(int x, int y, int z) {
-        Block vineBlock = Blocks.vine;
-        Random rand = this.rand;
-
-        List<Integer> validSides = new ArrayList<>();
-
-        for (int m = 2; m <= 5; ++m) {
-            int blockX = x + Facing.offsetsXForSide[m];
-            int blockY = y + Facing.offsetsYForSide[m];
-            int blockZ = z + Facing.offsetsZForSide[m];
-
-            if (this.worldObj.isAirBlock(blockX, blockY, blockZ)) {
-                validSides.add(1 << Direction.facingToDirection[Facing.oppositeSide[m]]);
-            } else {}
-        }
-
-        if (!validSides.isEmpty()) {
-            int maxLength = 8;
-            int length = rand.nextInt(maxLength) + 1;
-            int startY = y - length;
-            startY = Math.max(y - 8, startY);
-
-            batchPlaceVines(validSides, x, y, z, vineBlock, startY, y);
-        }
-    }
-
-    private void batchPlaceVines(List<Integer> validSides, int x, int y, int z, Block vineBlock, int startY, int maxY) {
-        for (int vineSide : validSides) {
-            placeVinesBottomUp(x, y, z, vineBlock, vineSide, startY, maxY);
-        }
-    }
-
-    private void placeVinesBottomUp(int x, int y, int z, Block vineBlock, int vineSide, int startY, int endY) {
-        int chunkX = x >> 4;
-        int chunkZ = z >> 4;
-        Chunk chunk = this.worldObj.getChunkFromChunkCoords(chunkX, chunkZ);
-
-        int adjustedJ = Math.min(y, endY);
-
-        for (int yCoord = adjustedJ; yCoord >= startY; --yCoord) {
-            int localX = x & 15;
-            int localZ = z & 15;
-
-            if (chunk.getBlock(localX, yCoord, localZ)
-                .isAir(this.worldObj, localX, yCoord, localZ)) {
-                chunk.func_150807_a(localX, yCoord, localZ, vineBlock, vineSide);
-            }
-        }
     }
 
     static {

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenTropicraftFlowers.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenTropicraftFlowers.java
@@ -1,10 +1,10 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.*;
+import java.util.Random;
 
-import net.minecraft.block.*;
-import net.minecraft.world.*;
-import net.tropicraft.registry.*;
+import net.minecraft.block.Block;
+import net.minecraft.world.World;
+import net.tropicraft.registry.TCBlockRegistry;
 
 public class WorldGenTropicraftFlowers extends TCGenBase {
 

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenTropicraftFlowers.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenTropicraftFlowers.java
@@ -1,11 +1,10 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.Random;
+import java.util.*;
 
-import net.minecraft.block.Block;
-import net.minecraft.world.World;
-import net.minecraft.world.chunk.Chunk;
-import net.tropicraft.registry.TCBlockRegistry;
+import net.minecraft.block.*;
+import net.minecraft.world.*;
+import net.tropicraft.registry.*;
 
 public class WorldGenTropicraftFlowers extends TCGenBase {
 
@@ -25,12 +24,6 @@ public class WorldGenTropicraftFlowers extends TCGenBase {
             final int x = i + this.rand.nextInt(8) - this.rand.nextInt(8);
             final int y = j + this.rand.nextInt(4) - this.rand.nextInt(4);
             final int z = k + this.rand.nextInt(8) - this.rand.nextInt(8);
-
-            Chunk chunk = worldObj.getChunkFromChunkCoords(x >> 4, z >> 4);
-            if (!chunk.isChunkLoaded) {
-                return false;
-            }
-
             Block blockAtPos = this.worldObj.getBlock(x, y, z);
             if (blockAtPos.isAir(worldObj, x, y, z) && TCBlockRegistry.flowers.canBlockStay(this.worldObj, x, y, z)
                 && this.rand.nextInt(3) == 0) {

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenTropicraftLargePalmTrees.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenTropicraftLargePalmTrees.java
@@ -1,13 +1,13 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.Random;
+import java.util.*;
 
-import net.minecraft.block.Block;
-import net.minecraft.init.Blocks;
-import net.minecraft.world.World;
-import net.minecraft.world.gen.feature.WorldGenerator;
-import net.tropicraft.block.BlockTropicraftLog;
-import net.tropicraft.registry.TCBlockRegistry;
+import net.minecraft.block.*;
+import net.minecraft.init.*;
+import net.minecraft.world.*;
+import net.minecraft.world.gen.feature.*;
+import net.tropicraft.block.*;
+import net.tropicraft.registry.*;
 
 public class WorldGenTropicraftLargePalmTrees extends WorldGenerator {
 
@@ -29,11 +29,10 @@ public class WorldGenTropicraftLargePalmTrees extends WorldGenerator {
     public boolean generate(final World world, final Random random, final int i, int j, final int k) {
         final int b = random.nextInt(2);
         final byte height = (byte) (random.nextInt(4) + 7);
-
+        boolean flag = true;
         if (j < 1 || j + height + 1 > 128) {
             return false;
         }
-
         for (int l = j; l <= j + 1 + height; ++l) {
             byte byte1 = 1;
             if (l == j) {
@@ -42,19 +41,21 @@ public class WorldGenTropicraftLargePalmTrees extends WorldGenerator {
             if (l >= j + 1 + height - 2) {
                 byte1 = 2;
             }
-
-            for (int j2 = i - byte1; j2 <= i + byte1; ++j2) {
-                for (int k2 = k - byte1; k2 <= k + byte1; ++k2) {
-                    if (l >= 0 && l < 128 && world.blockExists(j2, l, k2)) {
-                        Block block = world.getBlock(j2, l, k2);
-                        if (block != Blocks.air && block != TCBlockRegistry.palmLeaves) {
-                            return false;
+            for (int j2 = i - byte1; j2 <= i + byte1 && flag; ++j2) {
+                for (int k2 = k - byte1; k2 <= k + byte1 && flag; ++k2) {
+                    if (l >= 0 && l < 128) {
+                        final Block l2 = world.getBlock(j2, l, k2);
+                        if (l2 != Blocks.air && l2 != TCBlockRegistry.palmLeaves) {
+                            flag = false;
                         }
                     } else {
-                        return false;
+                        flag = false;
                     }
                 }
             }
+        }
+        if (!flag) {
+            return false;
         }
         Block i2 = world.getBlock(i, j - 1, k);
         if (i2 != Blocks.sand || j >= 128 - height - 1) {

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenTropicraftLargePalmTrees.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenTropicraftLargePalmTrees.java
@@ -1,13 +1,13 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.*;
+import java.util.Random;
 
-import net.minecraft.block.*;
-import net.minecraft.init.*;
-import net.minecraft.world.*;
-import net.minecraft.world.gen.feature.*;
-import net.tropicraft.block.*;
-import net.tropicraft.registry.*;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenerator;
+import net.tropicraft.block.BlockTropicraftLog;
+import net.tropicraft.registry.TCBlockRegistry;
 
 public class WorldGenTropicraftLargePalmTrees extends WorldGenerator {
 

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenTualang.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenTualang.java
@@ -1,11 +1,11 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.*;
+import java.util.Random;
 
-import net.minecraft.block.*;
-import net.minecraft.init.*;
-import net.minecraft.world.*;
-import net.tropicraft.registry.*;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.world.World;
+import net.tropicraft.registry.TCBlockRegistry;
 
 public class WorldGenTualang extends TCGenBase {
 

--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenTualang.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenTualang.java
@@ -1,17 +1,18 @@
 package net.tropicraft.world.worldgen;
 
-import java.util.Random;
+import java.util.*;
 
-import net.minecraft.block.Block;
-import net.minecraft.init.Blocks;
-import net.minecraft.world.World;
-import net.minecraft.world.chunk.Chunk;
-import net.tropicraft.registry.TCBlockRegistry;
+import net.minecraft.block.*;
+import net.minecraft.init.*;
+import net.minecraft.world.*;
+import net.tropicraft.registry.*;
 
 public class WorldGenTualang extends TCGenBase {
 
     private static final Block WOOD_BLOCK;
+    private static final int WOOD_META = 1;
     private static final Block LEAF_BLOCK;
+    private static final int LEAF_META = 1;
     private final int baseHeight;
     private final int maxHeight;
 
@@ -22,67 +23,60 @@ public class WorldGenTualang extends TCGenBase {
     }
 
     public boolean generate(final int i, final int j, final int k) {
-        Chunk chunk = worldObj.getChunkFromChunkCoords(i >> 4, k >> 4);
-        if (!chunk.isChunkLoaded) {
-            return false;
-        }
         final int height = this.rand.nextInt(this.maxHeight - this.baseHeight) + this.baseHeight + j;
         final int branches = this.rand.nextInt(3) + 3;
-
         if (height + 6 > 256) {
             return false;
         }
-
         final Block blockUnder = this.worldObj.getBlock(i, j - 1, k);
         if (blockUnder != Blocks.dirt && blockUnder != Blocks.grass) {
             return false;
         }
-
-        if (checkBlocks(i, j, k, height)) {
-            return false;
-        }
-
-        buildTrunk(i, j, k, height);
-
-        generateBranches(i, k, height, branches);
-
-        return true;
-    }
-
-    private boolean checkBlocks(int i, int j, int k, int height) {
-        for (int y = j; y < j + height; ++y) {
-            Block block = this.worldObj.getBlock(i, y, k);
-            if (block != null && block.getMaterial()
-                .isOpaque()) {
-                return true;
+        for (int x = i - 1; x <= i + 1; ++x) {
+            for (int z = k - 1; z <= k + 1; ++z) {
+                for (int y = j; y < j + height; ++y) {
+                    final Block block = this.worldObj.getBlock(x, y, z);
+                    if (block.isOpaqueCube()) {
+                        return false;
+                    }
+                }
             }
         }
-        return false;
-    }
-
-    private void buildTrunk(int i, int j, int k, int height) {
-        for (int y = j; y < height; ++y) {
-            this.worldObj.setBlock(i, y, k, WorldGenTualang.WOOD_BLOCK, 1, WorldGenTualang.blockGenNotifyFlag);
+        for (int x = i - 9; x >= i + 9; ++x) {
+            for (int z = k - 9; z >= k + 9; ++z) {
+                for (int y = height; y < height + 6; ++y) {
+                    final Block block = this.worldObj.getBlock(x, y, z);
+                    if (block.isOpaqueCube()) {
+                        return false;
+                    }
+                }
+            }
         }
-    }
-
-    private void generateBranches(int i, int k, int height, int branches) {
+        this.worldObj.setBlock(i, j, k, Blocks.dirt, 0, WorldGenTualang.blockGenNotifyFlag);
+        this.worldObj.setBlock(i - 1, j, k, Blocks.dirt, 0, WorldGenTualang.blockGenNotifyFlag);
+        this.worldObj.setBlock(i + 1, j, k, Blocks.dirt, 0, WorldGenTualang.blockGenNotifyFlag);
+        this.worldObj.setBlock(i, j, k - 1, Blocks.dirt, 0, WorldGenTualang.blockGenNotifyFlag);
+        this.worldObj.setBlock(i, j, k + 1, Blocks.dirt, 0, WorldGenTualang.blockGenNotifyFlag);
+        for (int y2 = j; y2 < height; ++y2) {
+            this.worldObj.setBlock(i, y2, k, WorldGenTualang.WOOD_BLOCK, 1, WorldGenTualang.blockGenNotifyFlag);
+            this.worldObj.setBlock(i - 1, y2, k, WorldGenTualang.WOOD_BLOCK, 1, WorldGenTualang.blockGenNotifyFlag);
+            this.worldObj.setBlock(i + 1, y2, k, WorldGenTualang.WOOD_BLOCK, 1, WorldGenTualang.blockGenNotifyFlag);
+            this.worldObj.setBlock(i, y2, k - 1, WorldGenTualang.WOOD_BLOCK, 1, WorldGenTualang.blockGenNotifyFlag);
+            this.worldObj.setBlock(i, y2, k + 1, WorldGenTualang.WOOD_BLOCK, 1, WorldGenTualang.blockGenNotifyFlag);
+        }
         for (int x = 0; x < branches; ++x) {
             final int branchHeight = this.rand.nextInt(4) + 2 + height;
             final int bx = this.rand.nextInt(15) - 8 + i;
             final int bz = this.rand.nextInt(15) - 8 + k;
-
-            int midX = i + this.sign((bx - i) / 2);
-            int midZ = k + this.sign((bz - k) / 2);
-
-            for (int y = height; y <= branchHeight; y++) {
-                this.worldObj
-                    .setBlock(midX, y, midZ, WorldGenTualang.WOOD_BLOCK, 1, WorldGenTualang.blockGenNotifyFlag);
-            }
-
+            this.placeBlockLine(
+                new int[] { i + this.sign((bx - i) / 2), height, k + this.sign((bz - k) / 2) },
+                new int[] { bx, branchHeight, bz },
+                WorldGenTualang.WOOD_BLOCK,
+                1);
             this.genCircle(bx, branchHeight, bz, 2.0, 1.0, WorldGenTualang.LEAF_BLOCK, 1, false);
             this.genCircle(bx, branchHeight + 1, bz, 3.0, 2.0, WorldGenTualang.LEAF_BLOCK, 1, false);
         }
+        return true;
     }
 
     private int sign(final int i) {


### PR DESCRIPTION
## Summary

Chunk generation in the Tropicraft dimension caused crippling tick lag that froze the game â€” especially on entering the dimension via `/tropics`. Previous mitigations (the REUP `6ccba16` "Greatly reduce cascasding worldgens") moved the problem from lag to worldgen corruption: trees clipped at chunk borders, invisible blocks, vines floating in air. This PR fixes the *actual* cause â€” cascading chunk generation â€” structurally, so it is neither laggy **nor** clipping, and restores authentic pre-REUP Tropicraft worldgen.
Closes #36
Fixes #14

## Root cause

In 1.7.10, `World.getBlock`/`setBlock` on a coordinate whose chunk is unloaded synchronously generates and populates that chunk (`ChunkProviderServer.originalLoadChunk`). If that populate touches further unloaded chunks, it recurses â€” exponential, thread-blocking cascading worldgen. Vanilla only defers populate until the chunk's SE 2Ã—2 corner exists, so any decoration reaching W/N/NW hit ungenerated chunks and cascaded.

Tropicraft decorations reach far: trees, palms, sunken ships, the Home Tree and the Forest Altar Ruin all write/read 2â€“4 chunks out. The REUP approach (skip writes into unloaded chunks) eliminated the cascade but silently dropped blocks â€” the clipping/invisible-block bugs (issues #13/#14) the follow-up bugfix branches tried to patch.

## Changes

**Deferred decoration (`ChunkProviderTropicraft`)** â€” the structural fix

- A chunk's decorations now run only once its **9Ã—9 neighborhood (radius 4)** is fully generated, then applied exactly once. Radius 4 covers every reachable feature including the Forest Altar's 72-block tunnel.
- Because all decoration happens inside an already-loaded neighborhood, no block read/write can ever trigger a synchronous chunk load â€” cascading worldgen is *impossible* rather than merely reduced, and nothing is clipped.
- Per-chunk RNG seeding is unchanged, so decoration output is byte-faithful to immediate-decoration (the only difference is a pop-in band at the far edge of render distance, which is purely visual).
- Pending decorations are flushed from `populate`, from the per-tick `unloadQueuedChunks` hook, and at server stop via an `@Mod.EventHandler` `FMLServerStoppingEvent` (fires before the final save) so no chunk is ever saved with terrain but without its decorations.

**Restore pre-REUP worldgen accuracy (12 files)**

- Reverts REUP's edits back to `6ccba16^` in `TCGenBase`, `WorldGenHomeTree`, `WorldGenTallTree`, `WorldGenTualang`, `WorldGenCoffeePlant`, `WorldGenTCUndergrowth`, `WorldGenTallFlower`, `WorldGenBamboo`, `WorldGenTropicraftFlowers`, `WorldGenTropicraftLargePalmTrees`, `BiomeGenTropicraft`, `BiomeGenTropics`.
- Restores the 3Ã—3 Tualang trunk, canonical vine logic, flower density (12), and full tree shapes that REUP's guards had broken. The deferred gate replaces the need for every one of those guards.
- Keeps REUP's `getTerrainHeightAt` fallback (`return height` instead of `0`) so decorations never land in the void; and fixes the pre-REUP altar-ruin spawn bug where the Z coordinate was derived from the chunk's X (placing altars 20+ chunks away).

**Koa village scanning (`TownKoaVillageGenHelper`)**

- Village `isClear` probing now reads only already-loaded chunks (`getBlockIfLoaded`), removing the 86-block-radius cascade from beach chunk populate (the crash-server stack from the initial report). Unloaded probes are treated as "not clear"; `isClear` consumes no RNG, so other decoration is unaffected.

**Tropicraft teleporter (`TeleporterTropics`)** â€” the dimension-entry freeze

- Portal search (`placeInExistingPortal`, `makePortal`) scans only generated chunks, and `getTerrainHeightAt` falls back to sea level for ungenerated columns. The 297Ã—297Ã—256 brute-force that synchronously generated ~360 chunks on first `/tropics` is gone â€” entry is now near-instant, with the existing destinationCoordinateCache making return trips O(1).

**Invisible home-tree blocks (`WorldGenHomeTree`)**

- `placeBlock` writes with notify flag `0`; with deferred decoration the chunk is already sent to clients as terrain-only, so flag-0 writes never reached the client (the tree rendered invisible). All decoration writes now use flag 2 (`S23PacketBlockChange`).

**Debug instrumentation (kept, cheap)**

- A re-entrancy detector in `provideChunk` prints `[Tropicraft] CASCADING CHUNK GENERATION DETECTED` if any chunk is generated from inside decoration code. This is the permanent regression guard for this work.

## Verification

- `./gradlew compileJava` and `./gradlew spotlessCheck` pass.
- In-game: no freeze on dimension entry; no tick stalls while flying through freshly generated terrain at render distance 12; no clipped trees or invisible blocks; quit flushes pending decorations before save.
- The debug cascade detector dropped from 9 detected cascades (all traced to pre-existing altar bugs) to 0 after fixing the altar spawn coordinate.

## Notes / intentionally not changed

- **Altar origin read** (`WorldGenForestAltarRuin` line 47 reads raw local coords as world coords near chunk 0,0). Bounded, one-time, deliberately out of scope â€” tracked in **issue #37**.
- **Block flammability** (bugfix-12) is excluded; it has no bearing on worldgen.
- **bugfix-13 / bugfix-14** (invisible home-tree / mahogany-shape chasing REUP's guards) are superseded by the full pre-REUP revert. PR #19's contained fix is subsumed by this PR's flag-2 fix, and **PR #20 can be closed as obsolete**.
- **Quit time** is slightly longer (force-flush of the pop-in band before save) â€” the price of never saving undecorated chunks. A config toggle or persisted pending-set is a candidate follow-up if it bothers players.
