### PR TITLE
Fix Forest Altar Ruin probing world origin instead of the altar (Fixes #37)

### DIFF
--- a/src/main/java/net/tropicraft/world/worldgen/WorldGenForestAltarRuin.java
+++ b/src/main/java/net/tropicraft/world/worldgen/WorldGenForestAltarRuin.java
@@ -44,7 +44,7 @@ public class WorldGenForestAltarRuin extends TCDirectionalGen {
             while (x < width) {
                 for (int y2 = 0; y2 < 4; ++y2) {
                     terrainHeight = j + y2;
-                    if (this.worldObj.getBlock(x, terrainHeight, z) == TCBlockRegistry.logs) {
+                    if (this.getBlockWithDir(x, terrainHeight, z) == TCBlockRegistry.logs) {
                         ++x;
                     } else if (this.rand.nextInt(4) != 0) {
                         this.placeBlockWithDir(x, terrainHeight, z, Blocks.air, 0);


### PR DESCRIPTION
## Summary

When generating a Forest Altar Ruin, `WorldGenForestAltarRuin.generate` read local footprint coordinates as **world** coordinates, so the duplicate-log skip check probed blocks near the Tropicraft dimension's world origin (chunk 0,0) instead of the altar being built. This PR routes the read through the direction-aware accessor already used by every other access in the loop.

Closes #37

## Root cause

In `WorldGenForestAltarRuin.generate`, the loop parameters `x` (0..width) and `z` (0..length) are local offsets from the altar origin; every other access translates them to world coordinates through `TCDirectionalGen`'s rotation-aware helpers (`setOrigin` / `placeBlockWithDir` / `getTerrainHeightWithDir` / `getTEWithDir`). One read was left in raw local space:

```java
if (this.worldObj.getBlock(x, terrainHeight, z) == TCBlockRegistry.logs) {
```

With `x` ∈ 0..width−1 and `z` ∈ 0..length−1 (footprint ≤ 8×15 blocks), this probes world coordinates near (0, y, 0) — chunk 0,0 of the Tropicraft dimension:

1. **Wrong block check** — the "skip columns that already contain a log" guard inspected blocks near world origin rather than the altar being built, so the skip rarely behaved as intended.
2. **Last cascading-chunk-generation source** — if chunk 0,0 was not yet loaded when the altar was decorated (e.g. the player entered the dimension far from origin), `World.getBlock` synchronously generated and populated it from inside decoration code. This was the single remaining `CASCADING CHUNK GENERATION DETECTED` source after the deferred-decoration gate in #38.

## Changes

**`src/main/java/net/tropicraft/world/worldgen/WorldGenForestAltarRuin.java`** (1 line)

```java
// Before
if (this.worldObj.getBlock(x, terrainHeight, z) == TCBlockRegistry.logs) {

// After
if (this.getBlockWithDir(x, terrainHeight, z) == TCBlockRegistry.logs) {
```

`getBlockWithDir` applies the same origin + `dir` rotation mapping as the `placeBlockWithDir` writes in the same loop, so the check now reads exactly the altar column being generated and stays within the locally-loaded neighborhood covered by the deferred-decoration gate (radius 4).

## Verification

- `./gradlew compileJava` and `./gradlew spotlessCheck` pass.
- With the raw read gone, every block read/write in the altar's decoration path resolves inside the already-loaded gate neighborhood — chunk 0,0 is never touched, so the cascade detector cannot fire for altar generation.

## Notes / intentionally not changed

- The two `worldObj.getBlock(i, y, k)` reads above the altar origin are intentional: `i`/`k` are the generator's world-space origin parameters, and they gate generation (e.g. abort when the origin column holds water).

Closes #37